### PR TITLE
Fix mobile details view map click events on IE

### DIFF
--- a/styles/details.less
+++ b/styles/details.less
@@ -93,6 +93,7 @@
     .map-active-area {
       height: 300px;
       width: 100%;
+      background-color: rgba(255, 255, 255, 0); // Needed for the click events to work on IE.
     }
 
     .image-wrapper {


### PR DESCRIPTION
IE requires a background color on empty divs in order for mouse clicks to register on them.