### PR TITLE
Force show tour wizard button

### DIFF
--- a/src/app.coffee
+++ b/src/app.coffee
@@ -837,7 +837,7 @@ requirejs [
             tourButtonView = new TourStartButton()
             tourStartRegion.show tourButtonView
             @listenToOnce tourButtonView, 'close', => tourStartRegion.reset()
-        if not p13n.get('hide_tour') and p13n.get('skip_tour')
+        if p13n.get('skip_tour')
             showButton()
         @listenTo p13n, 'tour-skipped', =>
             showButton()


### PR DESCRIPTION
The tour wizard button remains hidden if they key was already set in the
browser's local storage. This fix removes the key test and shows the tour
button to those users also.

Fixes issue #247.