### PR TITLE
Show service berry in relevant division, fixes #360

### DIFF
--- a/src/control.coffee
+++ b/src/control.coffee
@@ -132,9 +132,12 @@ define [
                 @selectedDivision.clear()
             else
                 @selectedDivision.wrap division
+                id = @selectedDivision.attributes.value.attributes.unit?.id or null
+                # clear @units so the previous one doesn't persist if there is no new unit to draw
+                if id? then @renderUnitById(id, false) else @units.set []
                 division.set 'selected', true
 
-        renderUnitById: (id) ->
+        renderUnitById: (id, unitSelect=true) ->
             deferred = $.Deferred()
             unit = new Models.Unit id: id
             unit.fetch
@@ -142,7 +145,7 @@ define [
                     include: 'department,municipality,services'
                 success: =>
                     @setUnit unit
-                    @selectUnit unit
+                    if unitSelect then @selectUnit unit
                     deferred.resolve unit
             deferred.promise()
 

--- a/views/templates/division-list-item.jade
+++ b/views/templates/division-list-item.jade
@@ -5,3 +5,6 @@ a.division(href="#", class = selected ? 'selected': '')
     if name
       .title
         = name
+    else if unit
+      .title
+        = tAttr(unit.name)


### PR DESCRIPTION
Draw unit berry when drawing division borders related to an address. Also temporarily fixed swedish school names not showing on the division list (related to [backend issue #18](https://github.com/City-of-Helsinki/smbackend/issues/18)), which might become unnecessary when backend data problem is fixed.