### PR TITLE
More suitable unit specifier text when listing services

### DIFF
--- a/src/models.coffee
+++ b/src/models.coffee
@@ -312,12 +312,19 @@ define [
             else
                 "poi:tprek:#{@get 'id'}"
 
-        getSpecifierText: ->
+        getSpecifierText: (selectedServices) ->
             specifierText = ''
             unless @get('services')?
                 return specifierText
             level = null
             for service in @get 'services'
+                invalidService = false
+                if selectedServices
+                    #only allow specifiers that coincide with the root_service the selected query is under!
+                    for selected in selectedServices.models
+                        if service.root!=selected.attributes.root
+                            invalidService = true
+                continue if invalidService
                 if not level or service.level < level
                     specifierText = service.name[p13n.getLanguage()]
                     level = service.level

--- a/src/views/navigation.coffee
+++ b/src/views/navigation.coffee
@@ -158,6 +158,7 @@ define [
                         collectionType: 'service'
                         resultType: 'unit'
                         onlyResultType: true
+                        selectedServices: @selectedServices
                 when 'details'
                     view = new UnitDetailsView
                         model: @selectedUnits.first()

--- a/src/views/search-results.coffee
+++ b/src/views/search-results.coffee
@@ -41,6 +41,7 @@ define [
             'mouseenter': 'highlightResult'
         initialize: (opts) ->
             @order = opts.order
+            @selectedServices = opts.selectedServices
         selectResult: (ev) ->
             object_type = @model.get('object_type') or 'unit'
             switch object_type
@@ -56,7 +57,8 @@ define [
 
         serializeData: ->
             data = super()
-            data.specifier_text = @model.getSpecifierText()
+            # the selected services must be passed on to the model so we get proper specifier
+            data.specifier_text = @model.getSpecifierText(@selectedServices)
             switch @order
                 when 'distance'
                     fn = @model.getDistanceToLastPosition
@@ -76,6 +78,7 @@ define [
         itemView: SearchResultView
         itemViewOptions: ->
             order: @parent.getComparatorKey()
+            selectedServices: @parent.selectedServices
         initialize: (opts) ->
             super opts
             @parent = opts.parent
@@ -153,6 +156,7 @@ define [
             parent: @parent
             onlyResultType: @onlyResultType
             position: @position
+            selectedServices: @selectedServices
         }) ->
             @expansion = EXPAND_CUTOFF
             @$more = null


### PR DESCRIPTION
Addresses #324. However, tprek data does not contain information on "main service" as such, so it is impossible to address #324 in all cases, based on tprek data only.