### PR TITLE
Service cart on mobile.

### DIFF
--- a/styles/map-controls.less
+++ b/styles/map-controls.less
@@ -47,6 +47,7 @@
       left: 0;
       right: 0;
       text-align: center;
+      z-index: 1000;
     }
   }
 }
@@ -82,6 +83,7 @@
     & {
       right: 0;
       width: 100%;
+      z-index: 1000;
     }
 
     .bottom-logo {


### PR DESCRIPTION
Bring service cart on top of logo and disclaimers on mobile (< 768px). Closes #408.