### PR TITLE
Feature population statistics #509

### DIFF
--- a/locales/app.yaml
+++ b/locales/app.yaml
@@ -1409,3 +1409,16 @@ progress:
             units: Söker # TODO translate
             search: Söker # TODO translate
         rendering: Ritar # TODO verify
+statistics:
+    en:
+        people: __count__ people
+        person: __count__ person
+        no_data: no data
+    fi:
+        people: __count__ henkeä
+        person: __count__ henkilö
+        no_data: ei tietoja
+    sv:
+        people: __count__ personer
+        person: __count__ person
+        no_data: inga data

--- a/locales/app.yaml
+++ b/locales/app.yaml
@@ -63,17 +63,25 @@ service_cart:
         ortographic: Aerial view
         accessible_map: Accessible map
         background_map: Background map
-        data_layer: Population data
+        data_layer:
+            heatmap: Population heatmap
+            statistics: Area population statistics
         data_layers:
             null: Not selected
             all: All population
             age_0-6: Age 0-6 years
             age_7-12: Age 7-12 years
             age_13-17: Age 13-17 years
+            age_13-15: Age 13-17 years
+            age_16-29: Age 16-29 years
             age_18-29: Age 18-29 years
             age_30-64: Age 30-64 years
+            age_65-74: Age 64-75 years
             age_over_65: Age over 65 years
+            age_over_75: Age over 75 years
+            household-dwelling_unit: Mean household-dwelling unit size
             language_fi: Finnish speakers
+            language_fi-se: Finnish and Sami speakers
             language_sv: Swedish speakers
             language_other: Other language speakers
 
@@ -84,17 +92,25 @@ service_cart:
         ortographic: Ilmakuva
         accessible_map: Suurikontrastinen kartta
         background_map: Karttapohja
-        data_layer: Väestötiedot
+        data_layer:
+            heatmap: Väestötiedot - lämpökartta
+            statistics: Väestötiedot - tilastot
         data_layers:
             null: Ei väestötietoja
             all: Koko väestö
             age_0-6: Ikä 0-6 vuotta
             age_7-12: Ikä 7-12 vuotta
+            age_13-15: Ikä 13-15 vuotta
             age_13-17: Ikä 13-17 vuotta
+            age_16-29: Ikä 16-29 vuotta
             age_18-29: Ikä 18-29 vuotta
             age_30-64: Ikä 30-64 vuotta
+            age_65-74: Ikä 65-74 vuotta
             age_over_65: Ikä yli 65 vuotta
+            age_over_75: Ikä yli 75 vuotta
+            household-dwelling_unit: Asuntokunnan keskikoko
             language_fi: Suomenkieliset
+            language_fi-se: Suomen- ja saamenkieliset
             language_sv: Ruotsinkieliset
             language_other: Muunkieliset
     sv:
@@ -104,16 +120,24 @@ service_cart:
         ortographic: Flygbild
         accessible_map: Karta med stor kontrast
         background_map: Karta
-        data_layer: Populationsdata
+        data_layer:
+            heatmap: Population heatmap # FIX ME
+            statistics: Area population statistics # FIX ME
         data_layers:
             null: Inget val
             all: Alla invånare
             age_0-6: Ålder 0-6 år
             age_7-12: Ålder 7-12 år
+            age_13-15: Ålder 13-15 år
             age_13-17: Ålder 13-17 år
+            age_16-29: Ålder 16-29 år
             age_18-29: Ålder 18-29 år
             age_30-64: Ålder 30-64 år
+            age_65-74: Ålder 65-74 år
             age_over_65: Ålder over 65 år
+            age_over_75: Ålder over 75 år
+            household-dwelling_unit: Mean household-dwelling unit size # FIX ME
+            language_fi-se: Finsk- och samiskspråkiga
             language_fi: Finskspråkiga
             language_sv: Svenskspråkiga
             language_other: Andraspråkiga

--- a/locales/app.yaml
+++ b/locales/app.yaml
@@ -1414,11 +1414,14 @@ statistics:
         people: __count__ people
         person: __count__ person
         no_data: no data
+        forecast: forecast
     fi:
         people: __count__ henkeä
         person: __count__ henkilö
         no_data: ei tietoja
+        forecast: ennuste
     sv:
         people: __count__ personer
         person: __count__ person
         no_data: inga data
+        forecast: forecast # FIXME

--- a/src/app-state.coffee
+++ b/src/app-state.coffee
@@ -19,7 +19,7 @@ define (require) ->
             @selectedPosition = new models.WrappedModel()
             @selectedDivision = new models.WrappedModel()
             @divisions = new models.AdministrativeDivisionList
-            @statistics = new models.PopulationStatisticsList
+            @statistics = new models.PopulationStatistics
             @pendingFeedback = new models.FeedbackMessage()
             @dataLayers = new Backbone.Collection [], model: Backbone.Model
             @informationalMessage = new Backbone.Model()

--- a/src/app-state.coffee
+++ b/src/app-state.coffee
@@ -19,6 +19,7 @@ define (require) ->
             @selectedPosition = new models.WrappedModel()
             @selectedDivision = new models.WrappedModel()
             @divisions = new models.AdministrativeDivisionList
+            @statistics = new models.PopulationStatisticsList
             @pendingFeedback = new models.FeedbackMessage()
             @dataLayers = new Backbone.Collection [], model: Backbone.Model
             @informationalMessage = new Backbone.Model()

--- a/src/app.coffee
+++ b/src/app.coffee
@@ -299,6 +299,7 @@ define (require) ->
                 route: appModels.route
                 divisions: appModels.divisions
                 dataLayers: appModels.dataLayers
+                statistics: appModels.statistics
             cachedMapView = new MapView opts: opts, mapOpts: mapOpts, embedded: false
             window.mapView = cachedMapView
             map = cachedMapView.map

--- a/src/app.coffee
+++ b/src/app.coffee
@@ -410,6 +410,7 @@ define (require) ->
             "clearSelectedEvent"
 
             "toggleDivision"
+            "showDivisions"
 
             "setUnits"
             "setUnit"

--- a/src/cancel-token.coffee
+++ b/src/cancel-token.coffee
@@ -25,5 +25,6 @@ define (require) ->
         complete: ->
             @set 'active', false
             @set 'complete', true
+            @trigger 'complete'
         canceled: ->
             @get 'canceled'

--- a/src/control.coffee
+++ b/src/control.coffee
@@ -392,6 +392,17 @@ define (require) ->
                     @units.fetch opts
                     @units
 
+        showDivisions: (filters, cancelToken) ->
+            @divisions.clearFilters()
+            @divisions.setFilter 'geometry', true
+            for key, val of filters
+                @divisions
+                    .setFilter key, val
+            options = {cancelToken}
+            options.onPageComplete = => null
+            @divisions.fetchPaginated(options).done =>
+                @divisions.trigger 'finished'
+
         renderDivision: (municipality, divisionId, context) ->
             @_renderDivisions ["#{municipality}/#{divisionId}"], context
         renderMultipleDivisions: (_path, context) ->

--- a/src/control.coffee
+++ b/src/control.coffee
@@ -557,18 +557,18 @@ define (require) ->
             url = @_getRelativeUrl uri
             @router.navigate url
 
-        addDataLayer: (layerId) ->
+        addDataLayer: (layer, layerId) ->
             background = p13n.get 'map_background_layer'
             if background in ['servicemap', 'accessible_map']
                 @dataLayers.add id: layerId
             else
                 p13n.setMapBackgroundLayer 'servicemap'
-            p13n.toggleDataLayer layerId
-            @_setQueryParameter 'layer', layerId
-        removeDataLayer: (layerId) ->
+            p13n.toggleDataLayer layer, layerId
+            @_setQueryParameter layer, layerId
+        removeDataLayer: (layer, layerId) ->
             @dataLayers.remove (@dataLayers.where id: layerId)
-            p13n.toggleDataLayer null
-            @_removeQueryParameter 'layer'
+            p13n.toggleDataLayer layer, null
+            @_removeQueryParameter layer
 
         displayMessage: (messageId) ->
             @informationalMessage.set 'messageKey', messageId

--- a/src/control.coffee
+++ b/src/control.coffee
@@ -568,16 +568,15 @@ define (require) ->
             background = p13n.get 'map_background_layer'
             if background in ['servicemap', 'accessible_map']
                 @dataLayers.add
-                    id: layerId
-                    layer: layer
+                    dataId: layerId
+                    layerName: layer
             else
                 p13n.setMapBackgroundLayer 'servicemap'
             p13n.toggleDataLayer layer, layerId
             @_setQueryParameter layer, layerId
-        removeDataLayer: (layer, layerId) ->
+        removeDataLayer: (layer) ->
             @dataLayers.remove (@dataLayers.where
-                id: layerId
-                layer: layer
+                layerName: layer
             )
             p13n.toggleDataLayer layer, null
             @_removeQueryParameter layer

--- a/src/control.coffee
+++ b/src/control.coffee
@@ -23,6 +23,7 @@ define (require) ->
             @selectedPosition = appModels.selectedPosition
             @searchResults = appModels.searchResults
             @divisions = appModels.divisions
+            @statistics = appModels.statistics
             @selectedDivision = appModels.selectedDivision
             @level = appModels.level
             @dataLayers = appModels.dataLayers
@@ -392,7 +393,7 @@ define (require) ->
                     @units.fetch opts
                     @units
 
-        showDivisions: (filters, cancelToken) ->
+        showDivisions: (filters, statisticsKey ,cancelToken) ->
             @divisions.clearFilters()
             @divisions.setFilter 'geometry', true
             for key, val of filters
@@ -402,7 +403,9 @@ define (require) ->
             options.onPageComplete = => null
             cancelToken.activate()
             @divisions.fetchPaginated(options).done =>
-                @divisions.trigger 'finished', cancelToken
+                options = {cancelToken, key: statisticsKey}
+                @statistics.fetch(options).done (data) =>
+                    @divisions.trigger 'finished', cancelToken
 
         renderDivision: (municipality, divisionId, context) ->
             @_renderDivisions ["#{municipality}/#{divisionId}"], context
@@ -560,13 +563,18 @@ define (require) ->
         addDataLayer: (layer, layerId) ->
             background = p13n.get 'map_background_layer'
             if background in ['servicemap', 'accessible_map']
-                @dataLayers.add id: layerId
+                @dataLayers.add
+                    id: layerId
+                    layer: layer
             else
                 p13n.setMapBackgroundLayer 'servicemap'
             p13n.toggleDataLayer layer, layerId
             @_setQueryParameter layer, layerId
         removeDataLayer: (layer, layerId) ->
-            @dataLayers.remove (@dataLayers.where id: layerId)
+            @dataLayers.remove (@dataLayers.where
+                id: layerId
+                layer: layer
+            )
             p13n.toggleDataLayer layer, null
             @_removeQueryParameter layer
 

--- a/src/control.coffee
+++ b/src/control.coffee
@@ -405,7 +405,7 @@ define (require) ->
             cancelToken.activate()
             cancelToken.set 'cancelable', false
             @divisions.fetchPaginated(options).done =>
-                options = {cancelToken}
+                options = {cancelToken, statistical_districts: @divisions.models.map (div) -> div.get('origin_id')}
                 # Fetch statistics only when needed
                 if ( _.isEmpty(@statistics.attributes) )
                     @statistics.fetch(options).done (data) =>

--- a/src/control.coffee
+++ b/src/control.coffee
@@ -404,8 +404,12 @@ define (require) ->
             cancelToken.activate()
             @divisions.fetchPaginated(options).done =>
                 options = {cancelToken, key: statisticsKey}
-                @statistics.fetch(options).done (data) =>
-                    @divisions.trigger 'finished', cancelToken
+                # Fetch statistics only when needed
+                if ( _.isEmpty(@statistics.attributes) )
+                    @statistics.fetch(options).done (data) =>
+                        @divisions.trigger 'finished', cancelToken, statisticsKey
+                else
+                    @divisions.trigger 'finished', cancelToken, statisticsKey
 
         renderDivision: (municipality, divisionId, context) ->
             @_renderDivisions ["#{municipality}/#{divisionId}"], context

--- a/src/control.coffee
+++ b/src/control.coffee
@@ -393,7 +393,7 @@ define (require) ->
                     @units.fetch opts
                     @units
 
-        showDivisions: (filters, statisticsKey ,cancelToken) ->
+        showDivisions: (filters, statisticsPath ,cancelToken) ->
             @divisions.clearFilters()
             @divisions.setFilter 'geometry', true
             @divisions.setFilter 'type', 'statistical_district'
@@ -405,13 +405,13 @@ define (require) ->
             cancelToken.activate()
             cancelToken.set 'cancelable', false
             @divisions.fetchPaginated(options).done =>
-                options = {cancelToken, key: statisticsKey}
+                options = {cancelToken}
                 # Fetch statistics only when needed
                 if ( _.isEmpty(@statistics.attributes) )
                     @statistics.fetch(options).done (data) =>
-                        @divisions.trigger 'finished', cancelToken, statisticsKey
+                        @divisions.trigger 'finished', cancelToken, statisticsPath
                 else
-                    @divisions.trigger 'finished', cancelToken, statisticsKey
+                    @divisions.trigger 'finished', cancelToken, statisticsPath
 
         renderDivision: (municipality, divisionId, context) ->
             @_renderDivisions ["#{municipality}/#{divisionId}"], context

--- a/src/control.coffee
+++ b/src/control.coffee
@@ -400,8 +400,9 @@ define (require) ->
                     .setFilter key, val
             options = {cancelToken}
             options.onPageComplete = => null
+            cancelToken.activate()
             @divisions.fetchPaginated(options).done =>
-                @divisions.trigger 'finished'
+                @divisions.trigger 'finished', cancelToken
 
         renderDivision: (municipality, divisionId, context) ->
             @_renderDivisions ["#{municipality}/#{divisionId}"], context

--- a/src/control.coffee
+++ b/src/control.coffee
@@ -396,6 +396,7 @@ define (require) ->
         showDivisions: (filters, statisticsKey ,cancelToken) ->
             @divisions.clearFilters()
             @divisions.setFilter 'geometry', true
+            @divisions.setFilter 'type', 'statistical_district'
             for key, val of filters
                 @divisions
                     .setFilter key, val

--- a/src/control.coffee
+++ b/src/control.coffee
@@ -402,6 +402,7 @@ define (require) ->
             options = {cancelToken}
             options.onPageComplete = => null
             cancelToken.activate()
+            cancelToken.set 'cancelable', false
             @divisions.fetchPaginated(options).done =>
                 options = {cancelToken, key: statisticsKey}
                 # Fetch statistics only when needed
@@ -564,12 +565,13 @@ define (require) ->
             url = @_getRelativeUrl uri
             @router.navigate url
 
-        addDataLayer: (layer, layerId) ->
+        addDataLayer: (layer, layerId, leafletId) ->
             background = p13n.get 'map_background_layer'
             if background in ['servicemap', 'accessible_map']
                 @dataLayers.add
                     dataId: layerId
                     layerName: layer
+                    leafletId: leafletId
             else
                 p13n.setMapBackgroundLayer 'servicemap'
             p13n.toggleDataLayer layer, layerId

--- a/src/data-visualization.coffee
+++ b/src/data-visualization.coffee
@@ -12,6 +12,7 @@ define ->
             'language_fi':              'suom'
             'language_sv':              'ruots'
             'language_other':           'muunkiel'
+        # TODO: Remove household and languages from forecasts
         STATISTICS_DATASETS =
             'all':                      'väestö_yhteensä'
             'age_0-6':                  '06vuotiaat'

--- a/src/data-visualization.coffee
+++ b/src/data-visualization.coffee
@@ -2,16 +2,16 @@ define ->
     class DataVisualization
         # Data layers as in name: map_id
         HEATMAP_DATASETS =
-            'all':              'asyht'
-            'age_0-6':          'ika0_6'
-            'age_7-12':         'ika7_12'
-            'age_13-17':        'ika13_17'
-            'age_18-29':        'ika18_29'
-            'age_30-64':        'ika30_64'
-            'age_over_65':      'ika65_'
-            'language_fi':      'suom'
-            'language_sv':      'ruots'
-            'language_other':   'muunkiel'
+            'all':                      'asyht'
+            'age_0-6':                  'ika0_6'
+            'age_7-12':                 'ika7_12'
+            'age_13-17':                'ika13_17'
+            'age_18-29':                'ika18_29'
+            'age_30-64':                'ika30_64'
+            'age_over_65':              'ika65_'
+            'language_fi':              'suom'
+            'language_sv':              'ruots'
+            'language_other':           'muunkiel'
         STATISTICS_DATASETS =
             'all':                      'väestö_yhteensä'
             'age_0-6':                  '06vuotiaat'

--- a/src/data-visualization.coffee
+++ b/src/data-visualization.coffee
@@ -36,7 +36,10 @@ define ->
             unless HEATMAP_DATASETS[id]
                 return ''
             "http://geoserver.hel.fi/geoserver/gwc/service/wmts/?SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER=popdensity:alltest&style=popdensity:all_density_#{HEATMAP_DATASETS[id]}&FORMAT=image%2F#{layerFmt}&TILEMATRIXSET=ETRS-TM35FIN&TILEMATRIX=ETRS-TM35FIN:{z}&TILEROW={y}&TILECOL={x}"
-
+        
+        getStatisticsLayer: (name) ->
+            STATISTICS_DATASETS[name]
+            
         getHeatmapLayers: ->
             Object.keys HEATMAP_DATASETS
 

--- a/src/data-visualization.coffee
+++ b/src/data-visualization.coffee
@@ -12,7 +12,6 @@ define ->
             'language_fi':              'suom'
             'language_sv':              'ruots'
             'language_other':           'muunkiel'
-        # TODO: Remove household and languages from forecasts
         STATISTICS_DATASETS =
             'all':                      'väestö_yhteensä'
             'age_0-6':                  '06vuotiaat'
@@ -26,6 +25,15 @@ define ->
             'language_fi-se':           'suomi_ja_saame'
             'language_sv':              'ruotsi'
             'language_other':           'muu_kieli'
+        FORECAST_DATASETS =
+            'all':                      'väestö_yhteensä'
+            'age_0-6':                  '06vuotiaat'
+            'age_7-12':                 '712vuotiaat'
+            'age_13-15':                '1315vuotiaat'
+            'age_16-29':                '1629vuotiaat'
+            'age_30-64':                '3064vuotiaat'
+            'age_65-74':                '6574vuotiaat'
+            'age_over_75':              'yli_75vuotiaat'
         STATISTICS_TYPES =
             'current':                  'asuntokunnat'
             'forecast':                 'ennuste'
@@ -53,7 +61,7 @@ define ->
         getStatisticsLayers: ->
             Object.keys STATISTICS_DATASETS
 
-        getStatisticsTypes: ->
-            Object.keys STATISTICS_TYPES
+        getForecastsLayers: ->
+            Object.keys FORECAST_DATASETS
 
     new DataVisualization

--- a/src/data-visualization.coffee
+++ b/src/data-visualization.coffee
@@ -29,7 +29,7 @@ define ->
         getStrata: ->
             HEATMAP_DATASETS
 
-        dataLayerPath: (id) ->
+        heatmapLayerPath: (id) ->
             layerFmt = 'png'
             # "http://geoserver.hel.fi/geoserver/gwc/service/tms/1.0.0/popdensity:#{id}@ETRS-TM35FIN@#{layerFmt}/{z}/{x}/{y}.#{layerFmt}"
             # "http://geoserver.hel.fi/geoserver/gwc/service/wmts/?SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER=popdensity:alltest&FORMAT=image%2Fpng&TILEMATRIXSET=ETRS-TM35FIN&TILEMATRIX=ETRS-TM35FIN:15&TILEROW=26700&TILECOL=14500&STYLE=popdensity:all_density_suom"
@@ -37,7 +37,10 @@ define ->
                 return ''
             "http://geoserver.hel.fi/geoserver/gwc/service/wmts/?SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER=popdensity:alltest&style=popdensity:all_density_#{HEATMAP_DATASETS[id]}&FORMAT=image%2F#{layerFmt}&TILEMATRIXSET=ETRS-TM35FIN&TILEMATRIX=ETRS-TM35FIN:{z}&TILEROW={y}&TILECOL={x}"
 
-        getDataLayers: ->
-            DATA_LAYERS
+        getHeatmapLayers: ->
+            Object.keys HEATMAP_DATASETS
+
+        getStatisticsLayers: ->
+            Object.keys STATISTICS_DATASETS
 
     new DataVisualization

--- a/src/data-visualization.coffee
+++ b/src/data-visualization.coffee
@@ -25,6 +25,9 @@ define ->
             'language_fi-se':           'suomi_ja_saame'
             'language_sv':              'ruotsi'
             'language_other':           'muu_kieli'
+        STATISTICS_TYPES =
+            'current':                  'asuntokunnat'
+            'forecast':                 'ennuste'
         DATA_LAYERS = Object.keys HEATMAP_DATASETS
         getStrata: ->
             HEATMAP_DATASETS
@@ -39,11 +42,17 @@ define ->
         
         getStatisticsLayer: (name) ->
             STATISTICS_DATASETS[name]
+
+        getStatisticsType: (name) ->
+            STATISTICS_TYPES[name]
             
         getHeatmapLayers: ->
             Object.keys HEATMAP_DATASETS
 
         getStatisticsLayers: ->
             Object.keys STATISTICS_DATASETS
+
+        getStatisticsTypes: ->
+            Object.keys STATISTICS_TYPES
 
     new DataVisualization

--- a/src/data-visualization.coffee
+++ b/src/data-visualization.coffee
@@ -12,6 +12,19 @@ define ->
             'language_fi':      'suom'
             'language_sv':      'ruots'
             'language_other':   'muunkiel'
+        STATISTICS_DATASETS =
+            'all':                      'väestö_yhteensä'
+            'age_0-6':                  '06vuotiaat'
+            'age_7-12':                 '712vuotiaat'
+            'age_13-15':                '1315vuotiaat'
+            'age_16-29':                '1629vuotiaat'
+            'age_30-64':                '3064vuotiaat'
+            'age_65-74':                '6574vuotiaat'
+            'age_over_75':              'yli_75vuotiaat'
+            'household-dwelling_unit':  'asuntokuntien_keskikoko_hlöäasuntokunta'
+            'language_fi-se':           'suomi_ja_saame'
+            'language_sv':              'ruotsi'
+            'language_other':           'muu_kieli'
         DATA_LAYERS = Object.keys HEATMAP_DATASETS
         getStrata: ->
             HEATMAP_DATASETS

--- a/src/map-base-view.coffee
+++ b/src/map-base-view.coffee
@@ -233,9 +233,9 @@ define (require) ->
                 color: '#000'
                 fillColor: '#000'
                 style: (feature) ->
-                    fillOpacity: +(feature.properties?.proportion? && feature.properties.proportion)
+                    fillOpacity: +(feature.properties?.normalized? && feature.properties.normalized)
                 onEachFeature: (feature, layer) ->
-                    layer.bindPopup (+(feature.properties?.value? && feature.properties.value)).toString()
+                    layer.bindPopup (feature.properties?.value? && feature.properties.value)
             ).addTo(@map);
 
         drawDivisions: (divisions) ->

--- a/src/map-base-view.coffee
+++ b/src/map-base-view.coffee
@@ -10,6 +10,7 @@ define (require) ->
     widgets          = require 'cs!app/widgets'
     jade             = require 'cs!app/jade'
     MapStateModel    = require 'cs!app/map-state-model'
+    dataviz          = require 'cs!app/data-visualization'
     {getIeVersion}   = require 'cs!app/base'
 
     # TODO: remove duplicates
@@ -220,14 +221,16 @@ define (require) ->
             @map.adapt()
             mp.addTo @divisionLayer
 
-        drawDivisionsAsGeoJSONWithDataAttached: (divisions, statistics, statisticsKey) ->
+        drawDivisionsAsGeoJSONWithDataAttached: (divisions, statistics, statisticsPath) ->
+            type = dataviz.getStatisticsType(statisticsPath.split('.')[0])
+            layer = dataviz.getStatisticsLayer(statisticsPath.split('.')[1])
             geojson = divisions.map (division) =>
                 geometry:
                     coordinates: division.get('boundary').coordinates
                     type: 'MultiPolygon'
                 type: 'Feature'
                 properties:
-                    Object.assign({}, statistics.attributes[division.get('origin_id')]?[statisticsKey], {name: division.get('name')})
+                    Object.assign({}, statistics.attributes[division.get('origin_id')]?[type]?[layer], {name: division.get('name')})
             L.geoJson(geojson,
                 weight: 1
                 color: '#000'

--- a/src/map-base-view.coffee
+++ b/src/map-base-view.coffee
@@ -227,7 +227,7 @@ define (require) ->
                     type: 'MultiPolygon'
                 type: 'Feature'
                 properties:
-                    statistics.attributes[division.get('origin_id')]?[statisticsKey]
+                    Object.assign({}, statistics.attributes[division.get('origin_id')]?[statisticsKey], {name: division.get('name')})
             L.geoJson(geojson,
                 weight: 1
                 color: '#000'
@@ -235,7 +235,12 @@ define (require) ->
                 style: (feature) ->
                     fillOpacity: +(feature.properties?.normalized? && feature.properties.normalized)
                 onEachFeature: (feature, layer) ->
-                    layer.bindPopup (feature.properties?.value? && feature.properties.value)
+                    popupOpts =
+                        className: 'position'
+                        offset: L.point 0, -15
+                    popup = L.popup(popupOpts)
+                        .setContent jade.template('statistic-popup', feature.properties)
+                    layer.bindPopup popup
             ).addTo(@map);
 
         drawDivisions: (divisions) ->

--- a/src/map-base-view.coffee
+++ b/src/map-base-view.coffee
@@ -235,7 +235,7 @@ define (require) ->
                 style: (feature) ->
                     fillOpacity: +(feature.properties?.proportion? && feature.properties.proportion)
                 onEachFeature: (feature, layer) ->
-                    layer.bindPopup(+(feature.properties?.value? && feature.properties.value));
+                    layer.bindPopup (+(feature.properties?.value? && feature.properties.value)).toString()
             ).addTo(@map);
 
         drawDivisions: (divisions) ->

--- a/src/map-base-view.coffee
+++ b/src/map-base-view.coffee
@@ -220,32 +220,22 @@ define (require) ->
             @map.adapt()
             mp.addTo @divisionLayer
 
-        drawDivisionsAsGeoJSONWithDataAttached: (divisions, externalData) ->
-            ###externalData = # fake data: div id -> attributes
-                _.object divisions.map((division) ->
-                    id = division.get('origin_id')
-                    factor = Math.random()
-                    [id, {
-                        origin_id: division.get('origin_id'),
-                        absolute: factor * 5325,
-                        factor
-                    }])
-            externalData = statics.areaStats()###
+        drawDivisionsAsGeoJSONWithDataAttached: (divisions, statistics, statisticsKey) ->
             geojson = divisions.map (division) =>
                 geometry:
                     coordinates: division.get('boundary').coordinates
                     type: 'MultiPolygon'
                 type: 'Feature'
                 properties:
-                    externalData.get(division.get('origin_id'))?.attributes
+                    statistics.attributes[division.get('origin_id')]?[statisticsKey]
             L.geoJson(geojson,
                 weight: 1
                 color: '#000'
                 fillColor: '#000'
                 style: (feature) ->
-                    fillOpacity: +(feature.properties?.factor? && feature.properties.factor)
+                    fillOpacity: +(feature.properties?.proportion? && feature.properties.proportion)
                 onEachFeature: (feature, layer) ->
-                    layer.bindPopup(+(feature.properties?.absolute? && feature.properties.absolute) || 0);
+                    layer.bindPopup(+(feature.properties?.value? && feature.properties.value));
             ).addTo(@map);
 
         drawDivisions: (divisions) ->

--- a/src/map-base-view.coffee
+++ b/src/map-base-view.coffee
@@ -219,6 +219,33 @@ define (require) ->
             @map.adapt()
             mp.addTo @divisionLayer
 
+        drawDivisionsAsGeoJSONWithDataAttached: (divisions, externalData) ->
+            externalData = # fake data: div id -> attributes
+                _.object divisions.map((division) ->
+                    id = division.get('origin_id')
+                    factor = Math.random()
+                    [id, {
+                        origin_id: division.get('origin_id'),
+                        absolute: factor * 5325,
+                        factor
+                    }])
+            geojson = divisions.map (division) =>
+                geometry:
+                    coordinates: division.get('boundary').coordinates
+                    type: 'MultiPolygon'
+                type: 'Feature'
+                properties:
+                    externalData[division.get('origin_id')]
+            L.geoJson(geojson,
+                weight: 1,
+                color: '#000',
+                fillColor: '#000'
+                style: (feature) ->
+                    fillOpacity: feature.properties.factor
+                onEachFeature: (feature, layer) ->
+                    layer.bindPopup(feature.properties.absolute);
+            ).addTo(@map);
+
         drawDivisions: (divisions) ->
             geojson =
                 coordinates: @_combineMultiPolygons divisions.pluck('boundary')

--- a/src/map-base-view.coffee
+++ b/src/map-base-view.coffee
@@ -39,6 +39,7 @@ define (require) ->
             @selectedUnits = @opts.selectedUnits
             @selectedPosition = @opts.selectedPosition
             @divisions = @opts.divisions
+            @statistics = @opts.statistics
             @listenTo @units, 'reset', @drawUnits
             @listenTo @units, 'finished', (options) =>
                 # Triggered when all of the
@@ -220,7 +221,7 @@ define (require) ->
             mp.addTo @divisionLayer
 
         drawDivisionsAsGeoJSONWithDataAttached: (divisions, externalData) ->
-            externalData = # fake data: div id -> attributes
+            ###externalData = # fake data: div id -> attributes
                 _.object divisions.map((division) ->
                     id = division.get('origin_id')
                     factor = Math.random()
@@ -229,21 +230,22 @@ define (require) ->
                         absolute: factor * 5325,
                         factor
                     }])
+            externalData = statics.areaStats()###
             geojson = divisions.map (division) =>
                 geometry:
                     coordinates: division.get('boundary').coordinates
                     type: 'MultiPolygon'
                 type: 'Feature'
                 properties:
-                    externalData[division.get('origin_id')]
+                    externalData.get(division.get('origin_id'))?.attributes
             L.geoJson(geojson,
-                weight: 1,
-                color: '#000',
+                weight: 1
+                color: '#000'
                 fillColor: '#000'
                 style: (feature) ->
-                    fillOpacity: feature.properties.factor
+                    fillOpacity: +(feature.properties?.factor? && feature.properties.factor)
                 onEachFeature: (feature, layer) ->
-                    layer.bindPopup(feature.properties.absolute);
+                    layer.bindPopup(+(feature.properties?.absolute? && feature.properties.absolute) || 0);
             ).addTo(@map);
 
         drawDivisions: (divisions) ->

--- a/src/map-base-view.coffee
+++ b/src/map-base-view.coffee
@@ -224,6 +224,13 @@ define (require) ->
         drawDivisionsAsGeoJSONWithDataAttached: (divisions, statistics, statisticsPath) ->
             type = dataviz.getStatisticsType(statisticsPath.split('.')[0])
             layer = dataviz.getStatisticsLayer(statisticsPath.split('.')[1])
+            domainMax = Math.max(Object.keys(statistics.attributes).map( (id) ->
+                comparisonKey = statistics.attributes[id]?[type]?[layer]?.comparison
+                if isNaN(+statistics.attributes[id]?[type]?[layer]?[comparisonKey])
+                then 0
+                else +statistics.attributes[id][type][layer][comparisonKey]
+            )...)
+            app.vent.trigger 'statisticsDomainMax', domainMax
             geojson = divisions.map (division) =>
                 geometry:
                     coordinates: division.get('boundary').coordinates

--- a/src/map-view.coffee
+++ b/src/map-view.coffee
@@ -44,9 +44,9 @@ define (require) ->
                 position: null
                 clicked: null
 
-            @listenTo @divisions, 'finished', (cancelToken) =>
+            @listenTo @divisions, 'finished', (cancelToken, statisticsKey) =>
                 cancelToken.set 'status', 'rendering'
-                @visualizationLayer.addLayer @drawDivisionsAsGeoJSONWithDataAttached @divisions, @statistics
+                @visualizationLayer.addLayer @drawDivisionsAsGeoJSONWithDataAttached @divisions, @statistics, statisticsKey
                 cancelToken.complete()
 
             @dataLayers = @opts.dataLayers

--- a/src/map-view.coffee
+++ b/src/map-view.coffee
@@ -46,8 +46,7 @@ define (require) ->
 
             @listenTo @divisions, 'finished', (cancelToken) =>
                 cancelToken.set 'status', 'rendering'
-                @drawDivisionsAsGeoJSONWithDataAttached @divisions #,
-                    #externalData
+                @visualizationLayer.addLayer @drawDivisionsAsGeoJSONWithDataAttached @divisions, @statistics
                 cancelToken.complete()
 
             @dataLayers = @opts.dataLayers
@@ -480,7 +479,11 @@ define (require) ->
             @printer.printMap true
 
         addDataLayer: (layer) ->
-            lr = map.MapUtils.createHeatmapLayer(layer.get 'id')
+            switch(layer.get 'layer')
+                when 'heatmap_layer'
+                    lr = map.MapUtils.createHeatmapLayer(layer.get 'id')
+                when 'statistics_layer'
+                    lr = @drawDivisionsAsGeoJSONWithDataAttached(@divisions, @statistics)
             @visualizationLayer.addLayer lr
 
         removeDataLayer: ->

--- a/src/map-view.coffee
+++ b/src/map-view.coffee
@@ -46,7 +46,7 @@ define (require) ->
 
             @listenTo @divisions, 'finished', (cancelToken) =>
                 cancelToken.set 'status', 'rendering'
-                @drawDivisionsAsGeoJSONWithDataAttached @divisions#,
+                @drawDivisionsAsGeoJSONWithDataAttached @divisions #,
                     #externalData
                 cancelToken.complete()
 
@@ -480,7 +480,7 @@ define (require) ->
             @printer.printMap true
 
         addDataLayer: (layer) ->
-            lr = map.MapUtils.createDataLayer(layer.get 'id')
+            lr = map.MapUtils.createHeatmapLayer(layer.get 'id')
             @visualizationLayer.addLayer lr
 
         removeDataLayer: ->

--- a/src/map-view.coffee
+++ b/src/map-view.coffee
@@ -44,6 +44,9 @@ define (require) ->
                 position: null
                 clicked: null
 
+            @listenTo @divisions, 'finished', =>
+                @drawDivisions @divisions
+
             @dataLayers = @opts.dataLayers
 
             @listenTo @selectedServices, 'add', (service, collection) =>

--- a/src/map-view.coffee
+++ b/src/map-view.coffee
@@ -44,8 +44,11 @@ define (require) ->
                 position: null
                 clicked: null
 
-            @listenTo @divisions, 'finished', =>
-                @drawDivisions @divisions
+            @listenTo @divisions, 'finished', (cancelToken) =>
+                cancelToken.set 'status', 'rendering'
+                @drawDivisionsAsGeoJSONWithDataAttached @divisions#,
+                    #externalData
+                cancelToken.complete()
 
             @dataLayers = @opts.dataLayers
 

--- a/src/map-view.coffee
+++ b/src/map-view.coffee
@@ -46,15 +46,16 @@ define (require) ->
                 position: null
                 clicked: null
 
-            @listenTo @divisions, 'finished', (cancelToken, statisticsKey) =>
+            @listenTo @divisions, 'finished', (cancelToken, statisticsPath) =>
                 cancelToken.set 'status', 'rendering'
+                [type, layer] = statisticsPath.split '.', 1
                 lr = @drawDivisionsAsGeoJSONWithDataAttached(
                     @divisions
                     @statistics
-                    dataviz.getStatisticsLayer statisticsKey)
+                    statisticsPath)
                 @visualizationLayer.addLayer lr
                 @closeAddressPopups()
-                app.request 'addDataLayer', 'statistics_layer', statisticsKey, lr._leaflet_id
+                app.request 'addDataLayer', 'statistics_layer', statisticsPath, lr._leaflet_id
 
                 cancelToken.complete()
 

--- a/src/map-view.coffee
+++ b/src/map-view.coffee
@@ -46,7 +46,7 @@ define (require) ->
 
             @listenTo @divisions, 'finished', (cancelToken, statisticsKey) =>
                 cancelToken.set 'status', 'rendering'
-                @visualizationLayer.addLayer @drawDivisionsAsGeoJSONWithDataAttached @divisions, @statistics, statisticsKey
+                @visualizationLayer.addLayer @drawDivisionsAsGeoJSONWithDataAttached(@divisions, @statistics, statisticsKey)
                 cancelToken.complete()
 
             @dataLayers = @opts.dataLayers
@@ -479,15 +479,16 @@ define (require) ->
             @printer.printMap true
 
         addDataLayer: (layer) ->
-            switch(layer.get 'layer')
+            switch(layer.get 'layerName')
                 when 'heatmap_layer'
-                    lr = map.MapUtils.createHeatmapLayer(layer.get 'id')
+                    lr = map.MapUtils.createHeatmapLayer(layer.get 'dataId')
                 when 'statistics_layer'
                     lr = @drawDivisionsAsGeoJSONWithDataAttached(@divisions, @statistics)
             @visualizationLayer.addLayer lr
+            layer.set('leafletId', lr._leaflet_id)
 
-        removeDataLayer: ->
-            @visualizationLayer.clearLayers()
+        removeDataLayer: (layer) ->
+            @visualizationLayer.removeLayer(layer.get('leafletId'))
 
         turnOnMeasureTool: ->
             # Hide address popup

--- a/src/map.coffee
+++ b/src/map.coffee
@@ -214,13 +214,13 @@ define (require) ->
             else
                 return 14
 
-        @createDataLayer: (id) ->
+        @createHeatmapLayer: (id) ->
             ###L.tileLayer.wms "http://geoserver.hel.fi/geoserver/popdensity/wms",
                 layers: id,
                 format: 'image/png',
                 transparent: true###
                 # TODO: select data set with style: parameter
-            L.tileLayer dataviz.dataLayerPath(id), bounds: [[60.09781624004459, 24.502779123289532],
+            L.tileLayer dataviz.heatmapLayerPath(id), bounds: [[60.09781624004459, 24.502779123289532],
                 [60.39870150471201, 25.247861779136283]]
 
     makeDistanceComparator = (p13n) =>

--- a/src/models.coffee
+++ b/src/models.coffee
@@ -462,9 +462,18 @@ define (require) ->
                 ((areas, key) ->
                     statistics = response.asuntokunnat[key]
                     statisticsName = key
+                    # Decide comparison value
+                    comparisonKey = if statistics[Object.keys(statistics)[0]].proportion != undefined then 'proportion' else 'value'
+                    maxVal = Math.max(Object.keys(statistics).map( (id) ->
+                        if isNaN(+statistics[id][comparisonKey]) then 0 else +statistics[id][comparisonKey]
+                    )...)
                     Object.keys(statistics).map( (id) ->
+                        statistic = statistics[id]
                         currentStatistic = {}
-                        currentStatistic[statisticsName] = statistics[id]
+                        value = if isNaN(+statistic[comparisonKey]) then 0 else statistic[comparisonKey]
+                        currentStatistic[statisticsName] =
+                            value: "" + statistic[comparisonKey]
+                            normalized: value / maxVal
                         areas[id] = Object.assign({}, areas[id], currentStatistic)
                     )
                     areas

--- a/src/models.coffee
+++ b/src/models.coffee
@@ -472,8 +472,9 @@ define (require) ->
                         currentStatistic = {}
                         value = if isNaN(+statistic[comparisonKey]) then 0 else statistic[comparisonKey]
                         currentStatistic[statisticsName] =
-                            value: "" + statistic[comparisonKey]
+                            value: "" + statistic.value
                             normalized: value / maxVal
+                            proportion: statistic.proportion
                         areas[id] = Object.assign({}, areas[id], currentStatistic)
                     )
                     areas

--- a/src/models.coffee
+++ b/src/models.coffee
@@ -485,6 +485,7 @@ define (require) ->
                                 value: "" + statistic.value
                                 normalized: value / maxVal
                                 proportion: proportion
+                                comparison: comparisonKey
                             data[id] = data[id] || {}
 
                             data[id][type] = Object.assign({}, data[id][type], currentStatistic)

--- a/src/models.coffee
+++ b/src/models.coffee
@@ -458,8 +458,9 @@ define (require) ->
     class PopulationStatistics extends SMModel
         resourceName: 'population_statistics'
         url: 'http://localhost:8000/areastats.json' # FIXME
-        parse: (response) ->
+        parse: (response, options) ->
             data = {};
+            originIds = options.statistical_districts;
             Object.keys(response).map (type) ->
                 Object.keys(response[type]).map(
                     ((key) ->
@@ -473,7 +474,7 @@ define (require) ->
                         maxVal = Math.max(Object.keys(statistics).map( (id) ->
                             if isNaN(+statistics[id][comparisonKey]) then 0 else +statistics[id][comparisonKey]
                         )...)
-                        Object.keys(statistics).map( (id) ->
+                        Object.keys(statistics).filter((id) -> originIds.indexOf(id) != -1).map( (id) ->
                             statistic = statistics[id]
                             currentStatistic = {}
                             value = if isNaN(+statistic[comparisonKey]) then 0 else statistic[comparisonKey]

--- a/src/models.coffee
+++ b/src/models.coffee
@@ -456,21 +456,21 @@ define (require) ->
 
     class PopulationStatistics extends SMModel
         resourceName: 'population_statistics'
-
-    class PopulationStatisticsList extends SMCollection
-        model: PopulationStatistics
         url: 'http://localhost:8000/areastats.json' # FIXME
-        parse: (response, options) ->
-            data = super response, options
-            data = response.asuntokunnat?[options.key || '']
-            data = Object.keys(data).map((value) ->
-                    return _.extend(data[value], {
-                        id: value,
-                        factor: data[value].proportion,
-                        absolute: data[value].value
-                    });
-            )
+        parse: (response) ->
+            data = Object.keys(response.asuntokunnat).reduce(
+                ((areas, key) ->
+                    statistics = response.asuntokunnat[key]
+                    statisticsName = key
+                    Object.keys(statistics).map( (id) ->
+                        currentStatistic = {}
+                        currentStatistic[statisticsName] = statistics[id]
+                        areas[id] = Object.assign({}, areas[id], currentStatistic)
+                    )
+                    areas
+                ), {})
             data
+
 
     class AdministrativeDivisionType extends SMModel
         resourceName: 'administrative_division_type'
@@ -985,7 +985,6 @@ define (require) ->
         AdministrativeDivisionType: AdministrativeDivisionType
         AdministrativeDivisionTypeList: AdministrativeDivisionTypeList
         PopulationStatistics: PopulationStatistics
-        PopulationStatisticsList: PopulationStatisticsList
         SearchList: SearchList
         Language: Language
         LanguageList: LanguageList

--- a/src/models.coffee
+++ b/src/models.coffee
@@ -459,34 +459,37 @@ define (require) ->
         resourceName: 'population_statistics'
         url: 'http://localhost:8000/areastats.json' # FIXME
         parse: (response) ->
-            data = Object.keys(response.asuntokunnat).reduce(
-                ((areas, key) ->
-                    statistics = response.asuntokunnat[key]
-                    statisticsName = key
-                    isHouseholdDwellingUnit = statisticsName == dataviz.getStatisticsLayer('household-dwelling_unit')
-                    # Decide comparison value
-                    comparisonKey = if statistics[Object.keys(statistics)[0]].proportion != undefined && !isHouseholdDwellingUnit
-                    then 'proportion'
-                    else 'value'
-                    maxVal = Math.max(Object.keys(statistics).map( (id) ->
-                        if isNaN(+statistics[id][comparisonKey]) then 0 else +statistics[id][comparisonKey]
-                    )...)
-                    Object.keys(statistics).map( (id) ->
-                        statistic = statistics[id]
-                        currentStatistic = {}
-                        value = if isNaN(+statistic[comparisonKey]) then 0 else statistic[comparisonKey]
-                        # Filter out proportion for average household-dwelling unit sizes
-                        proportion = if isHouseholdDwellingUnit
-                        then undefined
-                        else statistic.proportion
-                        currentStatistic[statisticsName] =
-                            value: "" + statistic.value
-                            normalized: value / maxVal
-                            proportion: proportion
-                        areas[id] = Object.assign({}, areas[id], currentStatistic)
-                    )
-                    areas
-                ), {})
+            data = {};
+            Object.keys(response).map (type) ->
+                Object.keys(response[type]).map(
+                    ((key) ->
+                        statistics = response[type][key]
+                        statisticsName = key
+                        isHouseholdDwellingUnit = statisticsName == dataviz.getStatisticsLayer('household-dwelling_unit')
+                        # Decide comparison value
+                        comparisonKey = if statistics[Object.keys(statistics)[0]].proportion != undefined && !isHouseholdDwellingUnit
+                        then 'proportion'
+                        else 'value'
+                        maxVal = Math.max(Object.keys(statistics).map( (id) ->
+                            if isNaN(+statistics[id][comparisonKey]) then 0 else +statistics[id][comparisonKey]
+                        )...)
+                        Object.keys(statistics).map( (id) ->
+                            statistic = statistics[id]
+                            currentStatistic = {}
+                            value = if isNaN(+statistic[comparisonKey]) then 0 else statistic[comparisonKey]
+                            # Filter out proportion for average household-dwelling unit sizes
+                            proportion = if isHouseholdDwellingUnit
+                            then undefined
+                            else statistic.proportion
+                            currentStatistic[key] =
+                                value: "" + statistic.value
+                                normalized: value / maxVal
+                                proportion: proportion
+                            data[id] = data[id] || {}
+
+                            data[id][type] = Object.assign({}, data[id][type], currentStatistic)
+                        )
+                    ), {})
             data
 
 

--- a/src/models.coffee
+++ b/src/models.coffee
@@ -11,6 +11,7 @@ define (require) ->
     alphabet                   = require 'cs!app/alphabet'
     accessibility              = require 'cs!app/accessibility'
     {mixOf, pad, withDeferred} = require 'cs!app/base'
+    dataviz                    = require 'cs!app/data-visualization'
 
     BACKEND_BASE = appSettings.service_map_backend
     LINKEDEVENTS_BASE = appSettings.linkedevents_backend
@@ -462,8 +463,11 @@ define (require) ->
                 ((areas, key) ->
                     statistics = response.asuntokunnat[key]
                     statisticsName = key
+                    isHouseholdDwellingUnit = statisticsName == dataviz.getStatisticsLayer('household-dwelling_unit')
                     # Decide comparison value
-                    comparisonKey = if statistics[Object.keys(statistics)[0]].proportion != undefined then 'proportion' else 'value'
+                    comparisonKey = if statistics[Object.keys(statistics)[0]].proportion != undefined && !isHouseholdDwellingUnit
+                    then 'proportion'
+                    else 'value'
                     maxVal = Math.max(Object.keys(statistics).map( (id) ->
                         if isNaN(+statistics[id][comparisonKey]) then 0 else +statistics[id][comparisonKey]
                     )...)
@@ -471,10 +475,14 @@ define (require) ->
                         statistic = statistics[id]
                         currentStatistic = {}
                         value = if isNaN(+statistic[comparisonKey]) then 0 else statistic[comparisonKey]
+                        # Filter out proportion for average household-dwelling unit sizes
+                        proportion = if isHouseholdDwellingUnit
+                        then undefined
+                        else statistic.proportion
                         currentStatistic[statisticsName] =
                             value: "" + statistic.value
                             normalized: value / maxVal
-                            proportion: statistic.proportion
+                            proportion: proportion
                         areas[id] = Object.assign({}, areas[id], currentStatistic)
                     )
                     areas

--- a/src/models.coffee
+++ b/src/models.coffee
@@ -454,6 +454,24 @@ define (require) ->
     class AdministrativeDivisionList extends SMCollection
         model: AdministrativeDivision
 
+    class PopulationStatistics extends SMModel
+        resourceName: 'population_statistics'
+
+    class PopulationStatisticsList extends SMCollection
+        model: PopulationStatistics
+        url: 'http://localhost:8000/areastats.json' # FIXME
+        parse: (response, options) ->
+            data = super response, options
+            data = response.asuntokunnat?[options.key || '']
+            data = Object.keys(data).map((value) ->
+                    return _.extend(data[value], {
+                        id: value,
+                        factor: data[value].proportion,
+                        absolute: data[value].value
+                    });
+            )
+            data
+
     class AdministrativeDivisionType extends SMModel
         resourceName: 'administrative_division_type'
 
@@ -966,6 +984,8 @@ define (require) ->
         AdministrativeDivisionList: AdministrativeDivisionList
         AdministrativeDivisionType: AdministrativeDivisionType
         AdministrativeDivisionTypeList: AdministrativeDivisionTypeList
+        PopulationStatistics: PopulationStatistics
+        PopulationStatisticsList: PopulationStatisticsList
         SearchList: SearchList
         Language: Language
         LanguageList: LanguageList

--- a/src/p13n.coffee
+++ b/src/p13n.coffee
@@ -29,9 +29,9 @@ define (require) ->
         en: 'English'
     HEATMAP_LAYERS = dataviz.getHeatmapLayers()
 
-    STATISTICS_LAYERS = dataviz.getStatisticsTypes().reduce (layers, type) ->
-        layers = [layers..., dataviz.getStatisticsLayers().map( (layer) -> "#{type}.#{layer}")...]
-    ,[]
+    statistics_layers = dataviz.getStatisticsLayers().map (layer) -> "current.#{layer}"
+    forecast_layers = dataviz.getForecastsLayers().map (layer) -> "forecast.#{layer}"
+    STATISTICS_LAYERS = [statistics_layers..., forecast_layers...]
 
     ACCESSIBILITY_GROUPS = {
         senses: ['hearing_aid', 'visually_impaired', 'colour_blind'],

--- a/src/p13n.coffee
+++ b/src/p13n.coffee
@@ -90,6 +90,8 @@ define (require) ->
             bicycle:
                 bicycle_parked: true
                 bicycle_with: false
+        heatmap_layer: null
+        statistics_layer: null
 
     migrateCityFromV1ToV2 = (source) ->
         city = source.city

--- a/src/p13n.coffee
+++ b/src/p13n.coffee
@@ -28,7 +28,10 @@ define (require) ->
         sv: 'svenska'
         en: 'English'
     HEATMAP_LAYERS = dataviz.getHeatmapLayers()
-    STATISTICS_LAYERS = dataviz.getStatisticsLayers()
+
+    STATISTICS_LAYERS = dataviz.getStatisticsTypes().reduce (layers, type) ->
+        layers = [layers..., dataviz.getStatisticsLayers().map( (layer) -> "#{type}.#{layer}")...]
+    ,[]
 
     ACCESSIBILITY_GROUPS = {
         senses: ['hearing_aid', 'visually_impaired', 'colour_blind'],

--- a/src/p13n.coffee
+++ b/src/p13n.coffee
@@ -27,7 +27,8 @@ define (require) ->
         fi: 'suomi'
         sv: 'svenska'
         en: 'English'
-    DATA_LAYERS = dataviz.getDataLayers()
+    HEATMAP_LAYERS = dataviz.getHeatmapLayers()
+    STATISTICS_LAYERS = dataviz.getStatisticsLayers()
 
     ACCESSIBILITY_GROUPS = {
         senses: ['hearing_aid', 'visually_impaired', 'colour_blind'],
@@ -43,7 +44,8 @@ define (require) ->
             bicycle: ['bicycle_parked', 'bicycle_with']
         language: SUPPORTED_LANGUAGES
         map_background_layer: ['servicemap', 'ortographic', 'guidemap', 'accessible_map']
-        data_layer: [null, DATA_LAYERS...]
+        heatmap_layer: [null, HEATMAP_LAYERS...]
+        statistics_layer: [null, STATISTICS_LAYERS...]
         city: [null, 'helsinki', 'espoo', 'vantaa', 'kauniainen']
 
     PROFILE_IDS =
@@ -489,16 +491,22 @@ define (require) ->
                     name: layerName,
                     selected: @get('map_background_layer') == layerName
                 .value()
-        toggleDataLayer: (layerName) ->
-            oldLayer = @get 'data_layer'
+        toggleDataLayer: (layer, layerName) ->
             if layerName == 'null'
                 layerName = null
-            @_setValue ['data_layer'], layerName
+            @_setValue [layer], layerName
 
-        getDataLayers: ->
+        getHeatmapLayers: ->
             layers = []
-            ALLOWED_VALUES.data_layer.map (layerName) =>
-                layers.push {name: layerName, selected: @get('data_layer') == layerName}
+            ALLOWED_VALUES.heatmap_layer.map (layerName) =>
+                layers.push {name: layerName, selected: @get('heatmap_layer') == layerName}
+                return
+            layers
+
+        getStatisticsLayers: ->
+            layers = []
+            ALLOWED_VALUES.statistics_layer.map (layerName) =>
+                layers.push {name: layerName, selected: @get('statistics_layer') == layerName}
                 return
             layers
 

--- a/src/router.coffee
+++ b/src/router.coffee
@@ -17,8 +17,8 @@ define (require) ->
             @appRoute /^division(\?.*?)$/, 'renderMultipleDivisions'
 
         onPostRouteExecute: (context) ->
-            if context?.query?.layer?
-                app.request 'addDataLayer', context.query.layer
+            if context?.query?.heatmap_layer?
+                app.request 'addDataLayer', 'heatmap_layer', context.query.heatmap_layer
 
         executeRoute: (callback, args, context) ->
             callback?.apply(@, args)?.done (opts) =>

--- a/src/router.coffee
+++ b/src/router.coffee
@@ -19,6 +19,8 @@ define (require) ->
         onPostRouteExecute: (context) ->
             if context?.query?.heatmap_layer?
                 app.request 'addDataLayer', 'heatmap_layer', context.query.heatmap_layer
+            if context?.query?.statistics_layer?
+                app.request 'showDivisions', null, context.query.statistics_layer
 
         executeRoute: (callback, args, context) ->
             callback?.apply(@, args)?.done (opts) =>

--- a/src/views/loading-indicator.coffee
+++ b/src/views/loading-indicator.coffee
@@ -29,6 +29,7 @@ define (require) ->
         template: 'sidebar-loading-indicator'
         regions:
             indicator: '.loading-indicator-component'
+        isLoadingIndicator: true
         onDomRefresh: ->
             fn = =>
                 @$el.find('.content').removeClass 'hidden'

--- a/src/views/navigation.coffee
+++ b/src/views/navigation.coffee
@@ -57,6 +57,9 @@ define (require) ->
                     return if token.local
                     @change 'loading-indicator'
                 @listenTo wrappedValue, 'change:active', activeHandler
+                @listenTo wrappedValue, 'complete', =>
+                    if @contents.currentView.isLoadingIndicator
+                        @contents.empty()
                 wrappedValue.trigger 'change:active', wrappedValue, {}
                 wrappedValue.addHandler =>
                     @stopListening wrappedValue

--- a/src/views/service-cart.coffee
+++ b/src/views/service-cart.coffee
@@ -20,7 +20,7 @@ define (require) ->
             'click .map-layer label': 'selectLayerLabel'
             # 'click .data-layer a.toggle-layer': 'toggleDataLayer'
             #'click .data-layer label': 'selectDataLayerLabel'
-            'click .data-layer input': 'selectDataLayerInput'
+            'click .data-layer-heatmap input': (ev) -> @selectDataLayerInput('heatmap_layer', $(ev.currentTarget).prop('value'))
 
         initialize: ({@collection}) ->
             @listenTo @collection, 'add', @minimize
@@ -62,11 +62,10 @@ define (require) ->
             data.minimized = @minimized
             data.layers = p13n.getMapBackgroundLayers()
             data.selectedLayer = p13n.get('map_background_layer')
-            data.dataLayers = p13n.getDataLayers()
-            data.selectedDataLayer = p13n.get 'data_layer'
-            # Should default to null
-            unless data.selectedDataLayer
-                data.selectedDataLayer = null
+            data.heatmapLayers = p13n.getHeatmapLayers()
+            data.statisticsLayers = p13n.getStatisticsLayers()
+            data.selectedHeatmapLayer = p13n.get('heatmap_layer') || null
+            data.selectedStatisticsLayer = p13n.get('statistics_layer') || null
             data
         closeService: (ev) ->
             app.request 'removeService', $(ev.currentTarget).data('service')
@@ -76,9 +75,8 @@ define (require) ->
             @_selectLayer $(ev.currentTarget).attr('value')
         selectLayerLabel: (ev) ->
             @_selectLayer $(ev.currentTarget).data('layer')
-        selectDataLayerInput: (ev) ->
-            value = $(ev.currentTarget).prop('value')
-            app.request 'removeDataLayer', p13n.get('data_layer')
+        selectDataLayerInput: (dataLayer, value) ->
+            app.request 'removeDataLayer', dataLayer, p13n.get(dataLayer)
             unless value == 'null'
-                app.request 'addDataLayer', value
+                app.request 'addDataLayer', dataLayer, value
             @render()

--- a/src/views/service-cart.coffee
+++ b/src/views/service-cart.coffee
@@ -34,6 +34,9 @@ define (require) ->
             @listenTo p13n, 'change', (path, value) =>
                 if path[0] == 'map_background_layer' then @render()
                 if path[0] == 'statistics_layer' then @render()
+            @listenTo app.vent, 'statisticsDomainMax', (max) ->
+                @statisticsDomainMax = max
+                @render()
             @minimized = false
             if @collection.length
                 @minimized = false
@@ -76,6 +79,7 @@ define (require) ->
             data.selectedStatisticsLayer =
                 type: type
                 name: name
+                max: type && @statisticsDomainMax
             data
         closeService: (ev) ->
             app.request 'removeService', $(ev.currentTarget).data('service')

--- a/src/views/service-cart.coffee
+++ b/src/views/service-cart.coffee
@@ -3,8 +3,6 @@ define (require) ->
 
     p13n    = require 'cs!app/p13n'
     base    = require 'cs!app/views/base'
-    CancelToken = require 'cs!app/cancel-token'
-    dataviz = require 'cs!app/data-visualization'
 
     class ServiceCartView extends base.SMItemView
         template: 'service-cart'
@@ -22,8 +20,7 @@ define (require) ->
             # 'click .data-layer a.toggle-layer': 'toggleDataLayer'
             #'click .data-layer label': 'selectDataLayerLabel'
             'click .data-layer-heatmap input': (ev) -> @selectDataLayerInput('heatmap_layer', $(ev.currentTarget).prop('value'))
-            'click .data-layer-statistics input': (ev) -> #@selectDataLayerInput('statistics_layer', $(ev.currentTarget).prop('value'))
-                app.request 'showDivisions', null, dataviz.getStatisticsLayer($(ev.currentTarget).prop('value')), new CancelToken
+            'click .data-layer-statistics input': @selectStatisticsLayerInput
 
         initialize: ({@collection}) ->
             @listenTo @collection, 'add', @minimize
@@ -36,6 +33,7 @@ define (require) ->
             @listenTo @collection, 'minmax', @render
             @listenTo p13n, 'change', (path, value) =>
                 if path[0] == 'map_background_layer' then @render()
+                if path[0] == 'statistics_layer' then @render()
             @minimized = false
             if @collection.length
                 @minimized = false
@@ -79,7 +77,12 @@ define (require) ->
         selectLayerLabel: (ev) ->
             @_selectLayer $(ev.currentTarget).data('layer')
         selectDataLayerInput: (dataLayer, value) ->
-            app.request 'removeDataLayer', dataLayer, p13n.get(dataLayer)
+            app.request 'removeDataLayer', dataLayer
             unless value == 'null'
                 app.request 'addDataLayer', dataLayer, value
             @render()
+        selectStatisticsLayerInput: (ev) ->
+            value = $(ev.currentTarget).prop('value')
+            app.request 'removeDataLayer', 'statistics_layer'
+            if value != 'null'
+                app.request 'showDivisions', null, value

--- a/src/views/service-cart.coffee
+++ b/src/views/service-cart.coffee
@@ -3,6 +3,7 @@ define (require) ->
 
     p13n    = require 'cs!app/p13n'
     base    = require 'cs!app/views/base'
+    CancelToken = require 'cs!app/cancel-token'
     dataviz = require 'cs!app/data-visualization'
 
     class ServiceCartView extends base.SMItemView
@@ -21,6 +22,8 @@ define (require) ->
             # 'click .data-layer a.toggle-layer': 'toggleDataLayer'
             #'click .data-layer label': 'selectDataLayerLabel'
             'click .data-layer-heatmap input': (ev) -> @selectDataLayerInput('heatmap_layer', $(ev.currentTarget).prop('value'))
+            'click .data-layer-statistics input': (ev) -> #@selectDataLayerInput('statistics_layer', $(ev.currentTarget).prop('value'))
+                app.request 'showDivisions', null, dataviz.getStatisticsLayer($(ev.currentTarget).prop('value')), new CancelToken
 
         initialize: ({@collection}) ->
             @listenTo @collection, 'add', @minimize

--- a/src/views/service-cart.coffee
+++ b/src/views/service-cart.coffee
@@ -64,9 +64,18 @@ define (require) ->
             data.layers = p13n.getMapBackgroundLayers()
             data.selectedLayer = p13n.get('map_background_layer')
             data.heatmapLayers = p13n.getHeatmapLayers()
-            data.statisticsLayers = p13n.getStatisticsLayers()
+            data.statisticsLayers = p13n.getStatisticsLayers().map (layerPath) ->
+                {
+                    type: if layerPath?.name then layerPath.name.split('.')[0] else null
+                    name: if layerPath?.name then layerPath.name.split('.')[1] else null
+                    selected: layerPath.selected
+                }
             data.selectedHeatmapLayer = p13n.get('heatmap_layer') || null
-            data.selectedStatisticsLayer = p13n.get('statistics_layer') || null
+            selectedStatisticsLayer = p13n.get('statistics_layer')
+            [type, name] = if selectedStatisticsLayer then selectedStatisticsLayer.split('.') else [null, null]
+            data.selectedStatisticsLayer =
+                type: type
+                name: name
             data
         closeService: (ev) ->
             app.request 'removeService', $(ev.currentTarget).data('service')

--- a/styles/service-cart.less
+++ b/styles/service-cart.less
@@ -1,5 +1,7 @@
 #service-cart.overlay {
   z-index: 1000; // falls behind the search
+  max-height: 100vh;
+  overflow-y: scroll;
 
   ul {
     border-radius: 2px;

--- a/styles/service-cart.less
+++ b/styles/service-cart.less
@@ -188,6 +188,33 @@
         right: 8px;
         top: 8px;
       }
+
+      .statistics-legend {
+        
+        .progress {
+          background: linear-gradient(to right, rgba(0,0,0,0), rgba(0,0,0,1));
+          margin-bottom: 0;
+        }
+
+        .statistics-scale {
+          display: flex;
+          justify-content: center;
+          font-size: 14px;
+          & > div {
+            flex-grow: 1;
+            flex-basis: 0;
+          }
+          .start {
+            text-align: left;
+          }
+          .mid {
+            text-align: center
+          }
+          .end {
+            text-align: right;
+          }
+        }
+      }
     }
   }
 

--- a/views/templates/service-cart.jade
+++ b/views/templates/service-cart.jade
@@ -86,7 +86,9 @@ else
           = t('service_cart.data_layer.statistics')
           | : &nbsp;
           span
-            = t('service_cart.data_layers.' + selectedStatisticsLayer)
+            = t('service_cart.data_layers.' + selectedStatisticsLayer.name)
+          if selectedStatisticsLayer.type === 'forecast'
+            span  (#{t('statistics.forecast')}&nbsp;2020)
       #statistics-layers-collapse.collapse
         .collapse-content
           for layer in statisticsLayers
@@ -94,11 +96,14 @@ else
               - checked = 'checked'
             else
               - checked = null
-            - layer_id = 'layer-' + layer.name
-            label.layer(data-layer=layer.name, for!='statistics-' + layer_id)
-              input(type='radio', name='statistics-layers', id!='statistics-' + layer_id, value='' + layer.name, checked=checked, class=cls)
+            - layerPath = layer.type ? layer.type + '.' + layer.name : 'null'
+            - layer_id = 'layer-' + layerPath.replace('.', '-')
+            label.layer(data-layer="#{layerPath}", for!='statistics-' + layer_id)
+              input(type='radio', name='statistics-layers', id!='statistics-' + layer_id, value=layerPath, checked=checked, class=cls)
               | &nbsp;
               = t('service_cart.data_layers.' + layer.name)
+              if layer.type === 'forecast'
+                span  (#{t('statistics.forecast')}&nbsp;2020)
 
   each item in items
     li.services

--- a/views/templates/service-cart.jade
+++ b/views/templates/service-cart.jade
@@ -54,7 +54,7 @@ else
   //-           .progress-bar.progress-bar-danger(style='width:10%')
   //-             span.legend 10%
 
-  li.data-layer
+  li.data-layer.data-layer-heatmap
     div.data-layers
     span.layer-icon.icon-icon-areas-and-districts
     fieldset
@@ -63,19 +63,43 @@ else
           = t('service_cart.data_layer.heatmap')
           | : &nbsp;
           span
-            = t('service_cart.data_layers.' + selectedDataLayer)
+            = t('service_cart.data_layers.' + selectedHeatmapLayer)
       #heatmap-layers-collapse.collapse
         .collapse-content
-          for layer in dataLayers
+          for layer in heatmapLayers
             if layer.selected
               - checked = 'checked'
             else
               - checked = null
             - layer_id = 'layer-' + layer.name
-            label.layer(data-layer=layer.name, for!=layer_id)
-              input(type='radio', name='data-layers', id!=layer_id, value='' + layer.name, checked=checked, class=cls)
+            label.layer(data-layer=layer.name, for='heatmap-' +layer_id)
+              input(type='radio', name='heatmap-layers', id!='heatmap-' + layer_id, value='' + layer.name, checked=checked, class=cls)
               | &nbsp;
               = t('service_cart.data_layers.' + layer.name)
+
+  li.data-layer.data-layer-statistics
+    div.data-layers
+    span.layer-icon.icon-icon-areas-and-districts
+    fieldset
+      legend.service-cart-collapser
+        a.collapser.collapsed(data-toggle="collapse", href="#statistics-layers-collapse")
+          = t('service_cart.data_layer.statistics')
+          | : &nbsp;
+          span
+            = t('service_cart.data_layers.' + selectedStatisticsLayer)
+      #statistics-layers-collapse.collapse
+        .collapse-content
+          for layer in statisticsLayers
+            if layer.selected
+              - checked = 'checked'
+            else
+              - checked = null
+            - layer_id = 'layer-' + layer.name
+            label.layer(data-layer=layer.name, for!='statistics-' + layer_id)
+              input(type='radio', name='statistics-layers', id!='statistics-' + layer_id, value='' + layer.name, checked=checked, class=cls)
+              | &nbsp;
+              = t('service_cart.data_layers.' + layer.name)
+
   each item in items
     li.services
       div.service

--- a/views/templates/service-cart.jade
+++ b/views/templates/service-cart.jade
@@ -56,27 +56,15 @@ else
 
   li.data-layer
     div.data-layers
-     // span.layer-icon.icon-icon-map-options
-     // fieldset
-     //   legend= t('service_cart.data_layer')
-     //   for layer in datalayers
-     //     if layer.selected
-     //       - checked = 'checked'
-     //     else
-     //       - checked = null
-     //     - layer_id = 'layer-' + layer
-     //     label.layer(data-layer=layer.name, for!=layer - id)
-     //       input(type='radio', name='data-layers', id!=layer_id, value!=layer.name, checked=checked, class=cls)
-     //       | &nbsp;#{layer}
     span.layer-icon.icon-icon-areas-and-districts
     fieldset
       legend.service-cart-collapser
-        a.collapser.collapsed(data-toggle="collapse", href="#data-layers-collapse")
-          = t('service_cart.data_layer')
+        a.collapser.collapsed(data-toggle="collapse", href="#heatmap-layers-collapse")
+          = t('service_cart.data_layer.heatmap')
           | : &nbsp;
           span
             = t('service_cart.data_layers.' + selectedDataLayer)
-      #data-layers-collapse.collapse
+      #heatmap-layers-collapse.collapse
         .collapse-content
           for layer in dataLayers
             if layer.selected

--- a/views/templates/service-cart.jade
+++ b/views/templates/service-cart.jade
@@ -55,7 +55,6 @@ else
   //-             span.legend 10%
 
   li.data-layer.data-layer-heatmap
-    div.data-layers
     span.layer-icon.icon-icon-areas-and-districts
     fieldset
       legend.service-cart-collapser
@@ -78,7 +77,6 @@ else
               = t('service_cart.data_layers.' + layer.name)
 
   li.data-layer.data-layer-statistics
-    div.data-layers
     span.layer-icon.icon-icon-areas-and-districts
     fieldset
       legend.service-cart-collapser
@@ -89,6 +87,19 @@ else
             = t('service_cart.data_layers.' + selectedStatisticsLayer.name)
           if selectedStatisticsLayer.type === 'forecast'
             span  (#{t('statistics.forecast')}&nbsp;2020)
+          if selectedStatisticsLayer.max
+            .statistics-legend
+              .progress
+              .statistics-scale
+                - var format = selectedStatisticsLayer.max > 10 ? 0 : 1
+                - var unit = selectedStatisticsLayer.max <= 1 ? '%' : ''
+                - var correctedMax = selectedStatisticsLayer.max <= 1 ? selectedStatisticsLayer.max * 100 : selectedStatisticsLayer.max
+                .start
+                  = 0 + unit
+                .mid
+                  = (correctedMax / 2).toFixed(format) + unit
+                .end
+                  = (correctedMax).toFixed(format) + unit
       #statistics-layers-collapse.collapse
         .collapse-content
           for layer in statisticsLayers

--- a/views/templates/statistic-popup.jade
+++ b/views/templates/statistic-popup.jade
@@ -1,0 +1,7 @@
+.position-wrap.sm-popup.open
+  .arrow.bottom
+  .address
+    - var nameText = tAttr(name)
+    - var valueText = isNaN(+value) ? t('statistics.no_data') : ( value != 1 ? t('statistics.people', {count: value}) : t('statistics.person', {count: value}) )
+    - var proportionText = proportion  ? (proportion*100).toFixed(2) + "%" : ''
+    span #{nameText}, #{valueText} #{proportionText}


### PR DESCRIPTION
Fixes #509.
Still work in progress, but I have a few questions:
- How should those statistics popup behave & look? Should active statistics layer disable address popups?
- Does this need some kind of legend?
- For some datasets using proportion data for opacity seems irrelevant, eg. "Väestö yhteensä". In my opinion some kind of current value / max value ratio would be better in some cases. What do you think?

NOTE: Check the areastat.json URL from `models.coffee`. I'm using `http-server` npm package to serve the file locally: `http-server --cors -p 8000`.
