### PR TITLE
Show unit counts using selected cities, not totals

### DIFF
--- a/src/app.coffee
+++ b/src/app.coffee
@@ -59,8 +59,8 @@ define (require) ->
 
             @listenTo p13n, 'change', (path, val) ->
                 addBackgroundLayerAsBodyClass()
-                if path[path.length - 1] == 'city'
-                    @_reFetchAllServiceNodeUnits()
+            @listenTo p13n, 'city-change', ->
+                @_reFetchAllServiceNodeUnits()
 
             if DEBUG_STATE
                 @eventDebugger = new debug.EventDebugger appModels
@@ -203,8 +203,7 @@ define (require) ->
         _reFetchAllServiceNodeUnits: ->
             if @serviceNodes.length > 0
                 @units.reset []
-                @serviceNodes.each (s) => @_fetchServiceNodeUnits(s)
-
+                @serviceNodes.each (s) => @_fetchServiceNodeUnits(s, {}, new CancelToken)
 
         removeServiceNode: (serviceNodeId) ->
             serviceNode = @serviceNodes.get serviceNodeId

--- a/src/p13n.coffee
+++ b/src/p13n.coffee
@@ -245,6 +245,8 @@ define (require) ->
             @trigger 'change', path, val
             if path[0] == 'accessibility'
                 @trigger 'accessibility-change'
+            if path[0] == 'city'
+                @trigger 'city-change'
             val
 
         toggleMobility: (val) ->

--- a/src/views/service-tree.coffee
+++ b/src/views/service-tree.coffee
@@ -43,6 +43,7 @@ define (require) ->
                     @render()
             @listenTo @selectedServiceNodes, 'add', @render
             @listenTo @selectedServiceNodes, 'reset', @render
+            @listenTo p13n, 'city-change', @render
 
         toggleLeaf: (event) ->
             @toggleElement($(event.currentTarget).find('.show-badge-button'))
@@ -187,12 +188,10 @@ define (require) ->
                 if cities.length == 0
                     return unitCount.total
                 else
-                    filteredCities = _.pick(unitCount.municipality, cities)
-                    return _.reduce(
-                        _.values(filteredCities),
+                    filteredCities = _.pick unitCount.municipality, cities
+                    return _.reduce _.values(filteredCities),
                         (memo, value) -> memo + value,
                         0
-                    )
 
             cities = p13n.getCities()
 
@@ -204,7 +203,7 @@ define (require) ->
                 name: category.getText 'name'
                 classes: classes(category).join " "
                 has_children: category.get('children').length > 0
-                count: countUnits(cities, category)
+                count: countUnits cities, category
                 selected: selected
                 root_id: rootId
                 show_button_classes: @getShowButtonClasses selected, rootId

--- a/src/views/service-tree.coffee
+++ b/src/views/service-tree.coffee
@@ -2,6 +2,7 @@ define (require) ->
     _      = require 'underscore'
     i18n   = require 'i18next'
 
+    p13n   = require 'cs!app/p13n'
     models = require 'cs!app/models'
     base   = require 'cs!app/views/base'
 
@@ -181,16 +182,29 @@ define (require) ->
                 else
                     return ['service-node leaf']
 
+            countUnits = (cities, category) ->
+                unitCount = category.get('unit_count')
+                if cities.length == 0
+                    return unitCount.total
+                else
+                    filteredCities = _.pick(unitCount.municipality, cities)
+                    return _.reduce(
+                        _.values(filteredCities),
+                        (memo, value) -> memo + value,
+                        0
+                    )
+
+            cities = p13n.getCities()
+
             listItems = @collection.filter((c) => c.get('unit_count') != 0).map (category) =>
                 selected = @selected(category.id)
-
                 rootId = category.get 'root'
 
                 id: category.get 'id'
                 name: category.getText 'name'
                 classes: classes(category).join " "
                 has_children: category.get('children').length > 0
-                unit_count: category.get('unit_count')
+                count: countUnits(cities, category)
                 selected: selected
                 root_id: rootId
                 show_button_classes: @getShowButtonClasses selected, rootId

--- a/views/templates/service-tree.jade
+++ b/views/templates/service-tree.jade
@@ -31,4 +31,4 @@ ul.main-list.navi.service-tree.limit-max-height
             else
               = t('sidebar.show')
           .service-point-count
-            != t('general.units', {count: item.unit_count.total})
+            != t('general.units', {count: item.count})


### PR DESCRIPTION
- Show unit counts using selected cities instead of total counts
- Refresh unit counts when cities are changed while service tree is open
- Fix: Refresh search results when cities are changed; was broken, now fixed