### PR TITLE
If no results found in search, show info text for user

### DIFF
--- a/src/views/new-search-results.coffee
+++ b/src/views/new-search-results.coffee
@@ -250,6 +250,12 @@ define (require) ->
             view = @expandedView or _.values(@resultLayoutViews)[0]
             return unless view?
             #TODO test
+        serializeData: ->
+            data = super()
+            data.query = @collection.query
+            if data.query && data.items?.length == 0
+                data.noResults = true
+            data
         showChildViews: ->
             if @expanded
                 _(RESULT_TYPES).each (ctor, key) =>


### PR DESCRIPTION
This was a feature that was lost in some point and guessing from the code, it happened when there was transition from `search-results` to `new-search-results`. This fix adds needed changes to bring back old functionality.