### PR TITLE
Lower grunt watch interval to limit cpu usage

### DIFF
--- a/grunt/config/watch.coffee
+++ b/grunt/config/watch.coffee
@@ -1,5 +1,7 @@
 module.exports = (grunt) ->
   return {
+    options:
+      interval: 1000
     express:
       files: [
         'Gruntfile.coffee'


### PR DESCRIPTION
With the default watch interval, grunt watch fully consumes a cpu core (at least on mac) leading to lower battery life, heat etc.

Increase watch interval to 1000 ms to lower cpu usage.
