### PR TITLE
Fix/travel guide location detection issues

### DIFF
--- a/locales/app.yaml
+++ b/locales/app.yaml
@@ -394,6 +394,7 @@ transit:
         current_location: Current location
         location_pending: Detecting location
         user_picked_location: User picked location
+        location_forbidden: Detecting location not allowed
         depart: Depart
         arrive: Arrive
         start_location: Start
@@ -430,6 +431,7 @@ transit:
         current_location: Nykyinen sijaintini
         location_pending: Haetaan sijaintia
         user_picked_location: Poimittu sijainti
+        location_forbidden: Sijainnin haku ei ole sallittu
         depart: Lähtöaika
         arrive: Perillä
         start_location: Lähtö
@@ -483,6 +485,7 @@ transit:
         current_location: Min nuvarande position
         location_pending: Söker position
         user_picked_location: Position inhämtad
+        location_forbidden: Position sökning inte tillåt
         wait: Väntan
         at_destination: framme
         stops: hållplatser

--- a/src/models.coffee
+++ b/src/models.coffee
@@ -767,7 +767,10 @@ define (require) ->
                 else
                     return i18n.t('transit.current_location')
             else if object instanceof CoordinatePosition
-                return i18n.t('transit.user_picked_location')
+                if !object.isDetectedLocation()
+                    return i18n.t('transit.location_forbidden')
+                else
+                    return i18n.t('transit.user_picked_location')
             else if object instanceof Unit
                 return object.getText('name')
             else if object instanceof Position

--- a/src/models.coffee
+++ b/src/models.coffee
@@ -663,6 +663,8 @@ define (require) ->
             @isDetected
         isPending: ->
             !@get('location')?
+        setDetected: (value) ->
+            @isDetected = value
 
     class AddressPosition extends Position
         origin: -> 'address'

--- a/src/p13n.coffee
+++ b/src/p13n.coffee
@@ -364,7 +364,7 @@ define (require) ->
                     @get('transport_detailed_choices')[group].bicycle_parked = false
             @_setValue ['transport_detailed_choices', group, modeName], !oldVal
 
-        requestLocation: (positionModel) ->
+        requestLocation: (positionModel, cb) ->
             if appSettings.user_location_override
                 override = appSettings.user_location_override
                 coords =
@@ -379,8 +379,10 @@ define (require) ->
             posOpts =
                 enableHighAccuracy: false
                 timeout: 30000
-            navigator.geolocation.getCurrentPosition ((pos) => @_handleLocation(pos, positionModel)),
-                @_handleLocationError, posOpts
+            navigator.geolocation.getCurrentPosition ((pos) =>
+                @_handleLocation(pos, positionModel)
+                cb?()
+            ),  @_handleLocationError, posOpts
 
         set: (attr, val) ->
             if not attr of @attributes

--- a/src/views/route.coffee
+++ b/src/views/route.coffee
@@ -86,7 +86,7 @@ define (require) ->
                     @showRouteSummary null
                 if not previousOrigin
                     @routingParameters.setOrigin new models.CoordinatePosition
-                p13n.requestLocation @routingParameters.getOrigin()
+                p13n.requestLocation @routingParameters.getOrigin(), () => @routingParameters.getOrigin().setDetected(true)
 
             @routeSettingsRegion.show new RouteSettingsView
                 model: @routingParameters


### PR DESCRIPTION
Fixed few issues when detecting user location for travel guide. First of all inform user if location detection is not allowed. Then when acquiring location, set position status correctly. Before we ended up in situation that we had acquired location, but status was `isDetected = false`.