### PR TITLE
Fix map click problems

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -33,16 +33,16 @@ require.config({
     TweenLite: '../vendor/TweenLite',
     underscore: '../vendor/underscore',
     URI: '../vendor/URI',
-    'false': '../vendor/false'
+    false: '../vendor/false'
   },
   shim: {
-    'bootstrap': {
+    bootstrap: {
       deps: ['jquery']
     },
     'backbone.marionette': {
-        deps: ['backbone.babysitter', 'backbone.wreqr']
+      deps: ['backbone.babysitter', 'backbone.wreqr']
     },
-    'backbone': {
+    backbone: {
       deps: ['underscore', 'jquery'],
       exports: 'Backbone'
     },
@@ -70,15 +70,15 @@ require.config({
     'bootstrap-tour': {
       deps: ['bootstrap']
     },
-    'i18next': {
+    i18next: {
       exports: 'i18n'
     },
-    'iexhr': {
+    iexhr: {
       deps: ['jquery']
     },
     'leaflet.snogylop': {
       deps: ['leaflet']
-    },
+    }
   },
   config: {
     'cs!app/p13n': {
@@ -86,21 +86,25 @@ require.config({
     }
   },
   packages: [
-    {name: 'cs', location: '../vendor', main: 'cs'},
-    {name: 'coffee-script', location: '../vendor', main: 'coffee-script'}
+    { name: 'cs', location: '../vendor', main: 'cs' },
+    { name: 'coffee-script', location: '../vendor', main: 'coffee-script' }
   ],
   map: {
     '*': {
-        leaflet: 'app/leaflet-customized'
+      leaflet: 'app/leaflet-customized',
+      'leaflet.markercluster': 'app/leaflet.markercluster-customized'
     },
     'app/leaflet-customized': {
-         leaflet: 'leaflet'
+      leaflet: 'leaflet'
+    },
+    'app/leaflet.markercluster-customized': {
+      'leaflet.markercluster': 'leaflet.markercluster'
     },
     URI: {
-      'IPv6': 'false',
-      'punycode': 'false',
-      'SecondLevelDomains': 'false'
+      IPv6: 'false',
+      punycode: 'false',
+      SecondLevelDomains: 'false'
     }
   },
-  waitSeconds: 0,
-});
+  waitSeconds: 0
+})

--- a/src/leaflet-customized.js
+++ b/src/leaflet-customized.js
@@ -1,4 +1,22 @@
 define(['leaflet'], function(L) {
-    L.Map.prototype._originalGetBounds = L.Map.prototype.getBounds;
-    return L;
-});
+  L.Map.prototype._originalGetBounds = L.Map.prototype.getBounds
+
+  L.Path.prototype.onRemove = function(map) {
+    map
+      .off('viewreset', this.projectLatlngs, this)
+      .off('moveend', this._updatePath, this)
+
+    if (this.options.clickable) {
+      // This override removes the following line from original method:
+      // this._map.off('click', this._onClick, this);
+      this._map.off('mousemove', this._onMouseMove, this)
+    }
+
+    this._requestUpdate()
+
+    this.fire('remove')
+    this._map = null
+  }
+
+  return L
+})

--- a/src/leaflet.markercluster-customized.js
+++ b/src/leaflet.markercluster-customized.js
@@ -1,0 +1,29 @@
+define(['leaflet', 'leaflet.markercluster'], function(L) {
+  var _originalAnimationUnspiderfy =
+    L.MarkerCluster.prototype._animationUnspiderfy
+
+  L.MarkerCluster.prototype._animationUnspiderfy = function() {
+    _originalAnimationUnspiderfy.apply(this, arguments)
+
+    var group = this._group
+    var cluster = this
+
+    setTimeout(function() {
+      group.fire('unspiderfied', { cluster: cluster })
+    }, 200)
+  }
+
+  var _originalNoanimationUnspiderfy =
+    L.MarkerCluster.prototype._noanimationUnspiderfy
+
+  L.MarkerCluster.prototype._noanimationUnspiderfy = function() {
+    _originalNoanimationUnspiderfy.apply(this, arguments)
+
+    var group = this._group
+    var cluster = this
+
+    setTimeout(function() {
+      group.fire('unspiderfied', { cluster: cluster })
+    }, 200)
+  }
+})

--- a/src/map-base-view.coffee
+++ b/src/map-base-view.coffee
@@ -335,19 +335,19 @@ define (require) ->
                 showEvent: 'clustermouseover'
                 hideEvent: 'clustermouseout'
                 popupCreateFunction: _.bind @clusterPopup, @
-            markerClusterGroup.on 'spiderfied', (e) =>
-                icon = $(e.target._spiderfied?._icon)
-                icon?.fadeTo('fast', 0)
 
-            @_lastOpenedClusterIcon = null
+            # Work around css hover forced opacity showing the
+            # clicked cluster which should be hidden.
             markerClusterGroup.on 'spiderfied', (e) =>
-                # Work around css hover forced opacity showing the
-                # clicked cluster which should be hidden.
-                if @_lastOpenedClusterIcon
-                    L.DomUtil.removeClass @_lastOpenedClusterIcon, 'hidden'
                 icon = e.target._spiderfied._icon
-                L.DomUtil.addClass icon, 'hidden'
-                @_lastOpenedClusterIcon = icon
+                if icon
+                    $(icon).fadeTo('fast', 0)
+                    L.DomUtil.addClass icon, 'hidden'
+
+            markerClusterGroup.on 'unspiderfied', (e) =>
+                icon = e.cluster._icon
+                if icon
+                    L.DomUtil.removeClass icon, 'hidden'
 
         getZoomlevelToShowAllMarkers: ->
             layer = p13n.get('map_background_layer')


### PR DESCRIPTION
1. Fix address lookup popup no longer being functional after closing a marker cluster. Closing a cluster causes Leaflet (0.7 only) to remove all click handlers when Path objects (spider legs) are removed. Work around by customizing `L.Path.prototype.onRemove`

2. Fix marker clusters disappearing if clusters get closed by clicking anything else than another cluster. Fixed by adding an `unspiderfy` event similar to the one in newer version of the markercluster library. Requires editing the markercluster prototype.