### PR TITLE
Travel guide input improvements

### DIFF
--- a/locales/app.yaml
+++ b/locales/app.yaml
@@ -398,6 +398,7 @@ transit:
         location_pending: Detecting location
         user_picked_location: User picked location
         location_forbidden: Access to location denied
+        use_current_location: Use current location
         depart: Depart
         arrive: Arrive
         start_location: Start
@@ -435,6 +436,7 @@ transit:
         location_pending: Haetaan sijaintia
         user_picked_location: Poimittu sijainti
         location_forbidden: Sijainnin haku ei ole sallittu
+        use_current_location: Käytä nykyistä sijaintiani
         depart: Lähtöaika
         arrive: Perillä
         start_location: Lähtö
@@ -489,6 +491,7 @@ transit:
         location_pending: Söker position
         user_picked_location: Position inhämtad
         location_forbidden: Platsinfo får inte hämtas
+        use_current_location: Använda min nuvarande position
         wait: Väntan
         at_destination: framme
         stops: hållplatser

--- a/locales/app.yaml
+++ b/locales/app.yaml
@@ -398,7 +398,7 @@ transit:
         location_pending: Detecting location
         user_picked_location: User picked location
         location_forbidden: Access to location denied
-        use_current_location: Use current location
+        use_current_location: Use my current location
         depart: Depart
         arrive: Arrive
         start_location: Start
@@ -491,7 +491,7 @@ transit:
         location_pending: Söker position
         user_picked_location: Position inhämtad
         location_forbidden: Platsinfo får inte hämtas
-        use_current_location: Använda min nuvarande position
+        use_current_location: Använd min nuvarande position
         wait: Väntan
         at_destination: framme
         stops: hållplatser

--- a/src/models.coffee
+++ b/src/models.coffee
@@ -736,6 +736,7 @@ define (require) ->
             @set 'endpoints', attributes?.endpoints.slice(0) or [null, null]
             @set 'origin_index', attributes?.origin_index or 0
             @set 'time_mode', attributes?.time_mode or 'depart'
+            @set 'locked_index', attributes?.destination_index or 1
             @pendingPosition = new CoordinatePosition isDetected: false, preventPopup: true
             @listenTo @, 'change:time_mode', -> @triggerComplete()
 
@@ -758,6 +759,10 @@ define (require) ->
             @get('endpoints')[@_getDestinationIndex()]
         getOrigin: ->
             @get('endpoints')[@_getOriginIndex()]
+        getOriginLocked: ->
+            @_getOriginIndex() == @get 'locked_index'
+        getDestinationLocked: ->
+            @_getDestinationIndex() == @get 'locked_index'
         getEndpointName: (object) ->
             if not object?
                 return ''
@@ -775,8 +780,6 @@ define (require) ->
                 return object.getText('name')
             else if object instanceof Position
                 return object.humanAddress()
-        getEndpointLocking: (object) ->
-            return object instanceof models.Unit
         isComplete: ->
             for endpoint in @get 'endpoints'
                 unless endpoint? then return false

--- a/src/p13n.coffee
+++ b/src/p13n.coffee
@@ -198,10 +198,6 @@ define (require) ->
             else
                 cb()
 
-        _handleLocationError: (cb) => (error) =>
-            cb?()
-            @trigger 'position_error'
-            @set 'location_requested', false
 
         setVisited: ->
             @_setValue ['first_visit'], false
@@ -383,7 +379,11 @@ define (require) ->
             navigator.geolocation.getCurrentPosition ((pos) =>
                 @_handleLocation(pos, positionModel)
                 successCallback?()
-            ),  @_handleLocationError(failureCallback), posOpts
+            ),  () =>
+                failureCallback?()
+                @trigger 'position_error'
+                @set 'location_requested', false
+            , posOpts
 
         set: (attr, val) ->
             if not attr of @attributes

--- a/src/p13n.coffee
+++ b/src/p13n.coffee
@@ -198,7 +198,8 @@ define (require) ->
             else
                 cb()
 
-        _handleLocationError: (error) =>
+        _handleLocationError: (cb) => (error) =>
+            cb?()
             @trigger 'position_error'
             @set 'location_requested', false
 
@@ -364,7 +365,7 @@ define (require) ->
                     @get('transport_detailed_choices')[group].bicycle_parked = false
             @_setValue ['transport_detailed_choices', group, modeName], !oldVal
 
-        requestLocation: (positionModel, cb) ->
+        requestLocation: (positionModel, successCallback, failureCallback) ->
             if appSettings.user_location_override
                 override = appSettings.user_location_override
                 coords =
@@ -381,8 +382,8 @@ define (require) ->
                 timeout: 30000
             navigator.geolocation.getCurrentPosition ((pos) =>
                 @_handleLocation(pos, positionModel)
-                cb?()
-            ),  @_handleLocationError, posOpts
+                successCallback?()
+            ),  @_handleLocationError(failureCallback), posOpts
 
         set: (attr, val) ->
             if not attr of @attributes

--- a/src/views/route-settings.coffee
+++ b/src/views/route-settings.coffee
@@ -259,12 +259,12 @@ define (require) ->
         _isScreenHeightLow: ->
             $(window).innerHeight() < 700
 
-        _getInputText: (model, input) ->
+        _getInputText: (model, input, locked) ->
             longModelName = @_locationName model
             shortModelName = @_locationName model, true
             inputValue = $.trim input?.val()
 
-            if !@editing
+            if !@editing or locked
                 longModelName
             else
                 # if we are currently showing 'Current position' for the user and we don't
@@ -278,10 +278,10 @@ define (require) ->
                     inputValue
 
         _getOriginInputText: =>
-            @_getInputText @model.getOrigin(), @_getOriginInput()
+            @_getInputText @model.getOrigin(), @_getOriginInput(), @model.getOriginLocked()
 
         _getDestinationInputText: =>
-            @_getInputText @model.getDestination(), @_getDestinationInput()
+            @_getInputText @model.getDestination(), @_getDestinationInput(), @model.getDestinationLocked()
 
         serializeData: ->
             datetime = moment @model.getDatetime()

--- a/src/views/route-settings.coffee
+++ b/src/views/route-settings.coffee
@@ -161,12 +161,10 @@ define (require) ->
             @listenTo @model.getOrigin(), 'change', @render
             @listenTo @model.getDestination(), 'change', @render
 
-        _getInput: (selector) ->
-            @$el.find selector
         _getOriginInput: ->
-            @_getInput('.transit-start input.tt-input')
+            @$el.find '.transit-start input.tt-input'
         _getDestinationInput: ->
-            @_getInput('.transit-end input.tt-input')
+            @$el.find '.transit-end input.tt-input'
 
         onDomRefresh: ->
             @enableTypeahead '.transit-start input'
@@ -249,8 +247,11 @@ define (require) ->
                 $inputEl: $input
                 selectionCallback: selectAddress
 
-        _locationName: (object, short = false) =>
-            if short and object.object_type == 'address'
+        _locationName: (object) =>
+            @model.getEndpointName object
+
+        _locationShortName: (object) =>
+            if object.object_type == 'address'
                 object.humanAddress exclude: municipality: true
             else
                 @model.getEndpointName object
@@ -260,7 +261,7 @@ define (require) ->
 
         _getInputText: (model, input, locked) ->
             longModelName = @_locationName model
-            shortModelName = @_locationName model, true
+            shortModelName = @_locationShortName model
             inputValue = $.trim input?.val()
 
             if !@editing or locked
@@ -359,6 +360,7 @@ define (require) ->
                 @render()
 
         detectCurrentLocation: (ev) ->
+            ev.preventDefault()
             ev.stopPropagation()
             if @model.getOriginLocked()
                 @model.setDestination new models.CoordinatePosition

--- a/src/views/route-settings.coffee
+++ b/src/views/route-settings.coffee
@@ -38,6 +38,7 @@ define (require) ->
             @headerRegion.currentView.render()
             @accessibilitySummaryRegion.currentView.render()
             @transportModeControlsRegion.currentView.render()
+            @routeControllersRegion.currentView.render()
 
 
     class RouteSettingsHeaderView extends base.SMItemView
@@ -324,7 +325,7 @@ define (require) ->
                 @editing = true
             switch $(ev.currentTarget).attr 'data-endpoint'
                 when 'origin'
-                    # This is to make users life easier by focusin cursor
+                    # This is to make users life easier by focusing cursor
                     # to the end of the line
                     value = @_getOriginInputText()
                     @_getOriginInput().focus().val value
@@ -355,15 +356,23 @@ define (require) ->
             ev.stopPropagation()
             if @model.getOriginLocked()
                 @model.setDestination new models.CoordinatePosition
-                p13n.requestLocation @model.getDestination(), () =>
+                p13n.requestLocation @model.getDestination()
+                ,() =>
                     @model.getDestination().setDetected(true)
                     @applyChanges()
                     @render()
+                ,() =>
+                    @model.getDestination().setPending(false)
+                    @render()
             else
                 @model.setOrigin new models.CoordinatePosition
-                p13n.requestLocation @model.getOrigin(), () =>
+                p13n.requestLocation @model.getOrigin()
+                ,() =>
                     @model.getOrigin().setDetected(true)
                     @applyChanges()
+                    @render()
+                ,() =>
+                    @model.getOrigin().setPending(false)
                     @render()
 
     RouteSettingsView

--- a/src/views/route-settings.coffee
+++ b/src/views/route-settings.coffee
@@ -319,20 +319,24 @@ define (require) ->
                 when 'destination'
                     @model.getDestination()
 
+        _setInputValue: (input, value) ->
+            input.focus().val value
+            # This is for IE 10+
+            if input[0].setSelectionRange
+                input[0].setSelectionRange(value.length, value.length);
+
         editInput: (ev) ->
             ev.stopPropagation()
             if !@editing
                 @editing = true
-            switch $(ev.currentTarget).attr 'data-endpoint'
-                when 'origin'
-                    # This is to make users life easier by focusing cursor
-                    # to the end of the line
-                    value = @_getOriginInputText()
-                    @_getOriginInput().focus().val value
-                when 'destination'
-                    value = @_getDestinationInputText()
-                    @_getDestinationInput().focus().val value
-
+                # This is to make users life easier by focusing cursor
+                # to the end of the line and also making sure that user
+                # has the right input to edit
+                switch $(ev.currentTarget).attr 'data-endpoint'
+                    when 'origin'
+                        @_setInputValue @_getOriginInput(), @_getOriginInputText()
+                    when 'destination'
+                        @_setInputValue @_getDestinationInput(), @_getDestinationInputText()
 
         setTimeMode: (ev) ->
             ev.stopPropagation()

--- a/src/views/route-settings.coffee
+++ b/src/views/route-settings.coffee
@@ -123,6 +123,7 @@ define (require) ->
         template: 'route-controllers'
         events:
             'click .preset.unlocked': 'switchToLocationInput'
+            'click .detect-current-location': 'detectCurrentLocation'
             'click .preset-current-time': 'switchToTimeInput'
             'click .preset-current-date': 'switchToDateInput'
             'click .time-mode': 'setTimeMode'
@@ -302,5 +303,19 @@ define (require) ->
             @activateOnRender = 'date'
             @forceDateInput = true
             @model.trigger 'change'
+        detectCurrentLocation: (ev) ->
+            ev.stopPropagation()
+            if @model.getOriginLocked()
+                @model.setDestination new models.CoordinatePosition
+                p13n.requestLocation @model.getDestination(), () =>
+                    @model.getDestination().setDetected(true)
+                    @applyChanges()
+                    @render()
+            else
+                @model.setOrigin new models.CoordinatePosition
+                p13n.requestLocation @model.getOrigin(), () =>
+                    @model.getOrigin().setDetected(true)
+                    @applyChanges()
+                    @render()
 
     RouteSettingsView

--- a/src/views/route-settings.coffee
+++ b/src/views/route-settings.coffee
@@ -322,12 +322,15 @@ define (require) ->
             ev.stopPropagation()
             if !@editing
                 @editing = true
-                @render()
                 switch $(ev.currentTarget).attr 'data-endpoint'
                     when 'origin'
-                        @_getInput('.transit-start input').focus()
+                        # This is to make users life easier by focusin cursor
+                        # to the end of the line
+                        value = @_getOriginInputText()
+                        @_getInput('.transit-start input').focus().val value
                     when 'destination'
-                        @_getInput('.transit-end input').focus()
+                        value = @_getDestinationInputText()
+                        @_getInput('.transit-end input').focus().val value
 
         setTimeMode: (ev) ->
             ev.stopPropagation()

--- a/src/views/route-settings.coffee
+++ b/src/views/route-settings.coffee
@@ -144,8 +144,6 @@ define (require) ->
             @pendingPosition = @permanentModel.pendingPosition
             @currentUnit = attrs.unit
             @editing = false
-            @$originInput = null
-            @$destinationInput = null
             @_reset()
 
         _reset: ->
@@ -311,13 +309,6 @@ define (require) ->
             if @model.isComplete()
                 @applyChanges()
                 @render()
-
-        _getModelFromEvent: (ev) ->
-            switch $(ev.currentTarget).attr 'data-endpoint'
-                when 'origin'
-                    @model.getOrigin()
-                when 'destination'
-                    @model.getDestination()
 
         _setInputValue: (input, value) ->
             input.focus().val value

--- a/src/views/route-settings.coffee
+++ b/src/views/route-settings.coffee
@@ -322,15 +322,16 @@ define (require) ->
             ev.stopPropagation()
             if !@editing
                 @editing = true
-                switch $(ev.currentTarget).attr 'data-endpoint'
-                    when 'origin'
-                        # This is to make users life easier by focusin cursor
-                        # to the end of the line
-                        value = @_getOriginInputText()
-                        @_getInput('.transit-start input').focus().val value
-                    when 'destination'
-                        value = @_getDestinationInputText()
-                        @_getInput('.transit-end input').focus().val value
+            switch $(ev.currentTarget).attr 'data-endpoint'
+                when 'origin'
+                    # This is to make users life easier by focusin cursor
+                    # to the end of the line
+                    value = @_getOriginInputText()
+                    @_getOriginInput().focus().val value
+                when 'destination'
+                    value = @_getDestinationInputText()
+                    @_getDestinationInput().focus().val value
+
 
         setTimeMode: (ev) ->
             ev.stopPropagation()

--- a/src/views/route-settings.coffee
+++ b/src/views/route-settings.coffee
@@ -293,11 +293,11 @@ define (require) ->
             is_today: not @forceDateInput and datetime.isSame(today, 'day')
             is_tomorrow: datetime.isSame tomorrow, 'day'
             params: @model
-            get_origin_input_value: @_getOriginInputText()
-            get_destination_input_value: @_getDestinationInputText()
             origin:
+                name: @_getOriginInputText()
                 lock: @model.getOriginLocked()
             destination:
+                name: @_getDestinationInputText()
                 lock: @model.getDestinationLocked()
             time: datetime.format 'LT'
             date: datetime.format 'L'

--- a/src/views/route-settings.coffee
+++ b/src/views/route-settings.coffee
@@ -84,9 +84,9 @@ define (require) ->
 
         onDomRefresh: =>
             _(['public', 'bicycle']).each (group) =>
-                @$el.find(".#{group}-details a").click (ev) =>
-                    ev.preventDefault()
-                    @switchTransportDetails ev, group
+                @$el.find(".#{group}-details a").click (event) =>
+                    event.preventDefault()
+                    @switchTransportDetails event, group
 
         serializeData: ->
             transportModes = p13n.get('transport')
@@ -110,14 +110,14 @@ define (require) ->
             transport_detailed_choices: p13n.get('transport_detailed_choices')
             bicycle_details_classes: bicycleDetailsClasses
 
-        switchTransportMode: (ev) ->
-            ev.preventDefault()
-            type = $(ev.target).closest('li').data 'type'
+        switchTransportMode: (event) ->
+            event.preventDefault()
+            type = $(event.target).closest('li').data 'type'
             p13n.toggleTransport type
 
-        switchTransportDetails: (ev, group) ->
-            ev.preventDefault()
-            type = $(ev.target).closest('li').data 'type'
+        switchTransportDetails: (event, group) ->
+            event.preventDefault()
+            type = $(event.target).closest('li').data 'type'
             p13n.toggleTransportDetails group, type
 
     class RouteControllersView extends base.SMItemView
@@ -135,8 +135,8 @@ define (require) ->
             'click': 'undoChanges'
             # Important: the above click handler requires the following
             # to not disable the time picker widget.
-            'click .time': (ev) -> ev.stopPropagation()
-            'click .date': (ev) -> ev.stopPropagation()
+            'click .time': (event) -> event.stopPropagation()
+            'click .date': (event) -> event.stopPropagation()
 
         initialize: (attrs) ->
             window.debugRoutingControls = @
@@ -179,9 +179,9 @@ define (require) ->
                 @$el.find "input.#{key}"
             otherHider = (key) => =>
                 inputElement(other(key)).data("DateTimePicker")?.hide()
-            valueSetter = (key) => (ev) =>
+            valueSetter = (key) => (event) =>
                 keyUpper = key.charAt(0).toUpperCase() + key.slice 1
-                @model["set#{keyUpper}"].call @model, ev.date.toDate(),
+                @model["set#{keyUpper}"].call @model, event.date.toDate(),
                     alreadyVisible: true
                 @applyChanges()
 
@@ -302,8 +302,8 @@ define (require) ->
             date: datetime.format 'L'
             time_mode: @model.get 'time_mode'
 
-        swapEndpoints: (ev) ->
-            ev.stopPropagation()
+        swapEndpoints: (event) ->
+            event.stopPropagation()
             @permanentModel.swapEndpoints
                 silent: true
             @model.swapEndpoints()
@@ -317,34 +317,34 @@ define (require) ->
             if input[0].setSelectionRange
                 input[0].setSelectionRange(value.length, value.length);
 
-        editInput: (ev) ->
-            ev.stopPropagation()
+        editInput: (event) ->
+            event.stopPropagation()
             if !@editing
                 @editing = true
                 # This is to make users life easier by focusing cursor
                 # to the end of the line and also making sure that user
                 # has the right input to edit
-                switch $(ev.currentTarget).attr 'data-endpoint'
+                switch $(event.currentTarget).attr 'data-endpoint'
                     when 'origin'
                         @_setInputValue @_getOriginInput(), @_getOriginInputText()
                     when 'destination'
                         @_setInputValue @_getDestinationInput(), @_getDestinationInputText()
 
-        setTimeMode: (ev) ->
-            ev.stopPropagation()
-            timeMode = $(ev.target).data('value')
+        setTimeMode: (event) ->
+            event.stopPropagation()
+            timeMode = $(event.target).data('value')
             if timeMode != @model.get 'time_mode'
                 @model.setTimeMode(timeMode)
                 @applyChanges()
 
         _closeDatetimePicker: ($input) ->
             $input.data("DateTimePicker").hide()
-        switchToTimeInput: (ev) ->
-            ev.stopPropagation()
+        switchToTimeInput: (event) ->
+            event.stopPropagation()
             @activateOnRender = 'time'
             @model.setDefaultDatetime()
-        switchToDateInput: (ev) ->
-            ev.stopPropagation()
+        switchToDateInput: (event) ->
+            event.stopPropagation()
             @activateOnRender = 'date'
             @forceDateInput = true
             @model.trigger 'change'
@@ -359,9 +359,9 @@ define (require) ->
                 position.setPending(false)
                 @render()
 
-        detectCurrentLocation: (ev) ->
-            ev.preventDefault()
-            ev.stopPropagation()
+        detectCurrentLocation: (event) ->
+            event.preventDefault()
+            event.stopPropagation()
             if @model.getOriginLocked()
                 @model.setDestination new models.CoordinatePosition
                 @_processLocationDetection @model.getDestination()

--- a/src/views/route-settings.coffee
+++ b/src/views/route-settings.coffee
@@ -347,27 +347,24 @@ define (require) ->
             @activateOnRender = 'date'
             @forceDateInput = true
             @model.trigger 'change'
+
+        _processLocationDetection: (position) ->
+            p13n.requestLocation position
+            ,() =>
+                position.setDetected(true)
+                @applyChanges()
+                @render()
+            ,() =>
+                position.setPending(false)
+                @render()
+
         detectCurrentLocation: (ev) ->
             ev.stopPropagation()
             if @model.getOriginLocked()
                 @model.setDestination new models.CoordinatePosition
-                p13n.requestLocation @model.getDestination()
-                ,() =>
-                    @model.getDestination().setDetected(true)
-                    @applyChanges()
-                    @render()
-                ,() =>
-                    @model.getDestination().setPending(false)
-                    @render()
+                @_processLocationDetection @model.getDestination()
             else
                 @model.setOrigin new models.CoordinatePosition
-                p13n.requestLocation @model.getOrigin()
-                ,() =>
-                    @model.getOrigin().setDetected(true)
-                    @applyChanges()
-                    @render()
-                ,() =>
-                    @model.getOrigin().setPending(false)
-                    @render()
+                @_processLocationDetection @model.getOrigin()
 
     RouteSettingsView

--- a/src/views/route.coffee
+++ b/src/views/route.coffee
@@ -84,12 +84,12 @@ define (require) ->
                     @requestRoute()
                 @listenTo p13n, 'position_error', =>
                     @showRouteSummary null
-                if not previousOrigin
-                    @routingParameters.setOrigin new models.CoordinatePosition
-                else
-                    # This is need since we might have previous position
-                    # are not pending anymore
+                if previousOrigin
+                    # This is needed since we might have fetched the position earlier
+                    # and we need to reset pending (and possible other) states.
                     @routingParameters.getOrigin().initialize()
+                else
+                    @routingParameters.setOrigin new models.CoordinatePosition
 
                 p13n.requestLocation @routingParameters.getOrigin()
                 ,() =>

--- a/src/views/route.coffee
+++ b/src/views/route.coffee
@@ -94,6 +94,7 @@ define (require) ->
                 p13n.requestLocation @routingParameters.getOrigin()
                 ,() =>
                     @routingParameters.getOrigin().setDetected(true)
+                    @routeSettingsRegion.currentView.updateRegions()
                     @requestRoute()
                 ,() =>
                     @routingParameters.getOrigin().setPending(false)

--- a/src/views/route.coffee
+++ b/src/views/route.coffee
@@ -86,9 +86,11 @@ define (require) ->
                     @showRouteSummary null
                 if not previousOrigin
                     @routingParameters.setOrigin new models.CoordinatePosition
-                # This is need since we might have previous position
-                # are not pending anymore
-                @routingParameters.getOrigin().setPending(true)
+                else
+                    # This is need since we might have previous position
+                    # are not pending anymore
+                    @routingParameters.getOrigin().initialize()
+
                 p13n.requestLocation @routingParameters.getOrigin()
                 ,() =>
                     @routingParameters.getOrigin().setDetected(true)

--- a/styles/route-settings.less
+++ b/styles/route-settings.less
@@ -133,7 +133,18 @@
         width: auto;
         overflow-y: visible;
         overflow-x: visible;
+        background-color: @white !important;
+
+        &:focus {
+          background-color: @blue-lighter !important;
+        }
+
+        &.unlocked:hover {
+          cursor: pointer;
+          background-color: @blue-lighter !important;
+        }
       }
+
       border: none;
       height: @route-line-height;
 

--- a/views/templates/route-controllers.jade
+++ b/views/templates/route-controllers.jade
@@ -18,6 +18,11 @@
             a(href="#!", tabindex=(locked ? '-1' : null)).endpoint.endpoint-name!= destination.name
     a.swap-endpoints(href="#", tabindex='-1')
       span.icon-icon-forward
+  .row.current-location
+    .col-xs-12
+      - isDetected = !params.getOriginLocked() ? params.getOrigin().isDetectedLocation() : params.getDestination().isDetectedLocation()
+      a.detect-current-location.mode-switch(class=isDetected ? 'selected' : undefined)
+        = t('transit.use_current_location')
   .row.transit-time
     .col-xs-12
       a.time-mode.mode-switch.unlocked(data-value='depart' class=time_mode === 'depart' ? 'selected' : undefined)

--- a/views/templates/route-controllers.jade
+++ b/views/templates/route-controllers.jade
@@ -2,16 +2,18 @@
   .row.transit-endpoints
     .col-sm-6.col-xs-12.transit-start
       .input-wrapper
-        if params.getOrigin().isPending() && !params.getOrigin().isDetectedLocation()
-          input.endpoint(type="text", placeholder!=t('transit.input_placeholder'), data-endpoint='origin')
+        if origin_editing
+          - value = get_origin_input_value()
+          input.origin-input(type="text", placeholder!=t('transit.input_placeholder'), value!=value, data-endpoint='origin')
         else
           - locked = (origin.lock === true)
           .preset(data-route-node='start', class=origin.lock === true ? 'locked' : 'unlocked')
             a(href="#!", tabindex=(locked ? '-1' : null)).endpoint.endpoint-name!= origin.name
     .col-sm-6.col-xs-12.transit-end
       .input-wrapper
-        if params.getDestination().isPending() && !params.getDestination().isDetectedLocation()
-          input.endpoint(type="text", placeholder!=t('transit.input_placeholder'), data-endpoint='destination')
+        if destination_editing
+          - value = get_destination_input_value()
+          input.origin-input(type="text", placeholder!=t('transit.input_placeholder'), value!=value, data-endpoint='destination')
         else
           - locked = (destination.lock === true)
           .preset(data-route-node='end', class= locked ? 'locked' : 'unlocked')

--- a/views/templates/route-controllers.jade
+++ b/views/templates/route-controllers.jade
@@ -17,7 +17,7 @@
   .row.current-location
     .col-xs-12
       - isDetected = !params.getOriginLocked() ? params.getOrigin().isDetectedLocation() : params.getDestination().isDetectedLocation()
-      a.detect-current-location.mode-switch(class=isDetected ? 'selected' : undefined)
+      a.detect-current-location.mode-switch(href="#" class=isDetected ? 'selected' : undefined tabIndex="0")
         = t('transit.use_current_location')
   .row.transit-time
     .col-xs-12

--- a/views/templates/route-controllers.jade
+++ b/views/templates/route-controllers.jade
@@ -4,12 +4,14 @@
       .input-wrapper
           - locked = (origin.lock === true)
           - value = get_origin_input_value
-          input.origin-input(type="text", placeholder!=t('transit.input_placeholder'), value!=value, data-endpoint='origin' disabled=locked)
+          input.origin-input(type="text", placeholder!=t('transit.input_placeholder'),
+          value!=value, data-endpoint='origin' disabled=locked, class=locked ? 'locked' : 'unlocked')
     .col-sm-6.col-xs-12.transit-end
       .input-wrapper
           - locked = (destination.lock === true)
           - value = get_destination_input_value
-          input.destination-input(type="text", placeholder!=t('transit.input_placeholder'), value!=value, data-endpoint='destination' disabled=locked)
+          input.destination-input(type="text", placeholder!=t('transit.input_placeholder'),
+          value!=value, data-endpoint='destination' disabled=locked, class=locked ? 'locked' : 'unlocked')
     a.swap-endpoints(href="#", tabindex='-1')
       span.icon-icon-forward
   .row.current-location

--- a/views/templates/route-controllers.jade
+++ b/views/templates/route-controllers.jade
@@ -7,7 +7,7 @@
           input.origin-input(type="text", placeholder!=t('transit.input_placeholder'), value!=value, data-endpoint='origin')
         else
           - locked = (origin.lock === true)
-          .preset(data-route-node='start', class=origin.lock === true ? 'locked' : 'unlocked')
+          .preset(data-route-node='start', class=locked === true ? 'locked' : 'unlocked')
             a(href="#!", tabindex=(locked ? '-1' : null)).endpoint.endpoint-name!= origin.name
     .col-sm-6.col-xs-12.transit-end
       .input-wrapper
@@ -16,7 +16,7 @@
           input.origin-input(type="text", placeholder!=t('transit.input_placeholder'), value!=value, data-endpoint='destination')
         else
           - locked = (destination.lock === true)
-          .preset(data-route-node='end', class= locked ? 'locked' : 'unlocked')
+          .preset(data-route-node='end', class=locked ? 'locked' : 'unlocked')
             a(href="#!", tabindex=(locked ? '-1' : null)).endpoint.endpoint-name!= destination.name
     a.swap-endpoints(href="#", tabindex='-1')
       span.icon-icon-forward

--- a/views/templates/route-controllers.jade
+++ b/views/templates/route-controllers.jade
@@ -3,13 +3,13 @@
     .col-sm-6.col-xs-12.transit-start
       .input-wrapper
           - locked = (origin.lock === true)
-          - value = get_origin_input_value
+          - value = origin.name
           input.origin-input(type="text", placeholder!=t('transit.input_placeholder'),
           value!=value, data-endpoint='origin' disabled=locked, class=locked ? 'locked' : 'unlocked')
     .col-sm-6.col-xs-12.transit-end
       .input-wrapper
           - locked = (destination.lock === true)
-          - value = get_destination_input_value
+          - value = destination.name
           input.destination-input(type="text", placeholder!=t('transit.input_placeholder'),
           value!=value, data-endpoint='destination' disabled=locked, class=locked ? 'locked' : 'unlocked')
     a.swap-endpoints(href="#", tabindex='-1')

--- a/views/templates/route-controllers.jade
+++ b/views/templates/route-controllers.jade
@@ -2,22 +2,14 @@
   .row.transit-endpoints
     .col-sm-6.col-xs-12.transit-start
       .input-wrapper
-        if origin_editing
-          - value = get_origin_input_value()
-          input.origin-input(type="text", placeholder!=t('transit.input_placeholder'), value!=value, data-endpoint='origin')
-        else
           - locked = (origin.lock === true)
-          .preset(data-route-node='start', class=locked === true ? 'locked' : 'unlocked')
-            a(href="#!", tabindex=(locked ? '-1' : null)).endpoint.endpoint-name!= origin.name
+          - value = get_origin_input_value
+          input.origin-input(type="text", placeholder!=t('transit.input_placeholder'), value!=value, data-endpoint='origin' disabled=locked)
     .col-sm-6.col-xs-12.transit-end
       .input-wrapper
-        if destination_editing
-          - value = get_destination_input_value()
-          input.origin-input(type="text", placeholder!=t('transit.input_placeholder'), value!=value, data-endpoint='destination')
-        else
           - locked = (destination.lock === true)
-          .preset(data-route-node='end', class=locked ? 'locked' : 'unlocked')
-            a(href="#!", tabindex=(locked ? '-1' : null)).endpoint.endpoint-name!= destination.name
+          - value = get_destination_input_value
+          input.destination-input(type="text", placeholder!=t('transit.input_placeholder'), value!=value, data-endpoint='destination' disabled=locked)
     a.swap-endpoints(href="#", tabindex='-1')
       span.icon-icon-forward
   .row.current-location


### PR DESCRIPTION
This PR contains several small improvements to travel guide:

1. Make it possible to re-edit location input text.
2. Location input text is not cleared when choosing street list suggestion (this happened when only one suggestion available)
3. Improve location detection process by a) adding a distinction when we are pending to get the location and when we actually get it b) set correct status if user prevents location detection.