### PR TITLE
Removed unncessary collapse element from accessibility info

### DIFF
--- a/views/templates/unit-accessibility-details.jade
+++ b/views/templates/unit-accessibility-details.jade
@@ -44,15 +44,10 @@ a#accessibility-collapser.collapsed.collapser(data-toggle="collapse", data-paren
 
   if !sentence_error
     if groups.length
-      if profile_set && has_data
-          a.collapser.collapsed.sub-collapser(data-toggle="collapse", data-parent="#accessibility-details", href="#more-accessibility-details")
-            h4
-              = t('accessibility.accessibility_details')
-            #more-accessibility-details.collapse
-              +shortcomings(groups)
-      else
-          #more-accessibility-details
-              +shortcomings(groups)
+      h4
+        = t('accessibility.accessibility_details')
+      #more-accessibility-details
+        +shortcomings(groups)
     else
       if has_data
         div.icon.fa.fa-spinner.fa-spin


### PR DESCRIPTION
To reduce complexity, "Accessibility Details" -collapsing element was removed and the content is provided to user right away. 

### Before
https://www.dropbox.com/s/w0ollxrqp71184z/Screenshot%202018-11-07%2010.27.55.png?dl=0

### After
https://www.dropbox.com/s/lmnk0a28ppg6nz3/Screenshot%202018-11-07%2010.28.51.png?dl=0

Also "Accessibility Details" -title is shown also when no accessibility settings activated to avoid sudden title popping when activating settings.