### PR TITLE
Moved travel guide section after service details

### DIFF
--- a/views/templates/position.jade
+++ b/views/templates/position.jade
@@ -33,8 +33,6 @@
           br
           a.blue-link#add-circle(href="#")= t('position.show_within_radius')
 
-    .section.route-section
-
     .section.division-section
       a.collapser.collapsed.route(data-toggle="collapse", data-parent="#details-view-container", href="#service-details")
         h3
@@ -44,6 +42,8 @@
         h4= t('position.services.info')
         .area-service-nodes-placeholder
         #area-emergency-units-placeholder
+
+    .section.route-section
 
     .section.division-section
       a.collapser.collapsed.route(data-toggle="collapse", data-parent="#details-view-container", href="#division-details")


### PR DESCRIPTION
When looking address info in sidebar, we want to show service details before travel guide so that user gets the most relevant information first.

### Before
https://www.dropbox.com/s/kaqkq24oj5p4jzg/Screenshot%202018-11-07%2010.37.01.png?dl=0

### After
https://www.dropbox.com/s/8bbd3hsxjwjwa8i/Screenshot%202018-11-07%2010.37.34.png?dl=0