### PR TITLE
Feature/track personalisation changes to analytics

### DIFF
--- a/src/analytics.coffee
+++ b/src/analytics.coffee
@@ -10,6 +10,9 @@ define ->
                     serviceName = serviceModel.get('name')?.fi
                     if serviceName? then name = serviceName + " "
                     name += "#{serviceModel.get 'id'}"
+            when 'setPersonalisation'
+                name = "current_active_profile"
+                value = parameters[0]
         return {
             name: name
             value: value

--- a/src/analytics.coffee
+++ b/src/analytics.coffee
@@ -10,9 +10,9 @@ define ->
                     serviceName = serviceModel.get('name')?.fi
                     if serviceName? then name = serviceName + " "
                     name += "#{serviceModel.get 'id'}"
-            when 'setPersonalisation'
-                name = "current_active_profile"
-                value = parameters[0]
+            when 'personalisation'
+                name = parameters[0]
+                value = parameters[1]
         return {
             name: name
             value: value

--- a/src/p13n.coffee
+++ b/src/p13n.coffee
@@ -260,6 +260,8 @@ define (require) ->
             @_setValue ['accessibility', modeName], !oldVal
         setAccessibilityMode: (modeName, val) ->
             @_setValue ['accessibility', modeName], val
+        getAccessibilityModes: ->
+            @get 'accessibility'
         getAccessibilityMode: (modeName) ->
             accVars = @get 'accessibility'
             if not modeName of accVars

--- a/src/views/personalisation.coffee
+++ b/src/views/personalisation.coffee
@@ -48,8 +48,8 @@ define (require) ->
                 @renderIconsForSelectedModes()
             @listenTo p13n, 'user:open', -> @personalisationButtonClick()
             @_triggerProfileAnalytics = _.debounce (() =>
-                Analytics.trackCommand 'setPersonalisation', [JSON.stringify(@_getCurrentProfile())]
-            ), 15000
+                Analytics.trackCommand 'personalisation', ['setProfile', JSON.stringify(@_getCurrentProfile())]
+            ), 10000
         serializeData: ->
             lang: p13n.getLanguage()
 

--- a/src/views/personalisation.coffee
+++ b/src/views/personalisation.coffee
@@ -1,8 +1,10 @@
 define (require) ->
+    _                                = require 'underscore'
     p13n                             = require 'cs!app/p13n'
     base                             = require 'cs!app/views/base'
     AccessibilityPersonalisationView = require 'cs!app/views/accessibility-personalisation'
     {getLangURL}                     = require 'cs!app/base'
+    Analytics                = require 'cs!app/analytics'
 
     class PersonalisationView extends base.SMLayout
         className: 'personalisation-container'
@@ -45,6 +47,9 @@ define (require) ->
                 @setActivations()
                 @renderIconsForSelectedModes()
             @listenTo p13n, 'user:open', -> @personalisationButtonClick()
+            @_triggerProfileAnalytics = _.debounce (() =>
+                Analytics.trackCommand 'setPersonalisation', [JSON.stringify(@_getCurrentProfile())]
+            ), 15000
         serializeData: ->
             lang: p13n.getLanguage()
 
@@ -108,6 +113,17 @@ define (require) ->
                     $li.removeClass 'selected'
                 $button.attr 'aria-pressed', activated
 
+        _getCurrentProfile: ->
+            profile = {}
+            profile.cities = p13n.getCities()
+            profile.language = p13n.getLanguage()
+            accessibility = p13n.getAccessibilityModes()
+            _.each(_.keys(accessibility), (key) ->
+                if accessibility[key]
+                    profile[key] = accessibility[key]
+            )
+            profile
+
         switchPersonalisation: (ev) =>
             ev.preventDefault()
             parentLi = $(ev.target).closest 'li'
@@ -134,6 +150,7 @@ define (require) ->
                 p13n.toggleCity type
             else if group == 'language'
                 window.location.href = getLangURL type
+            @_triggerProfileAnalytics()
 
         onDomRefresh: ->
             @renderIconsForSelectedModes()


### PR DESCRIPTION
We want to track what kind of personalisation settings are used in Servicemap. With this implementation the active profile settings are sent to analytics after 10 seconds from first change (to give time to the user to set "final" settings).