### PR TITLE
Show focus effect for division detail list items

### DIFF
--- a/styles/details.less
+++ b/styles/details.less
@@ -359,7 +359,7 @@
         border-top: 1px solid #ddd;
         min-height: 57px;
       }
-      > li > a:focus {
+      > li > a {
         display: block;
       }
       .selected {

--- a/styles/details.less
+++ b/styles/details.less
@@ -358,7 +358,9 @@
         margin: 0;
         border-top: 1px solid #ddd;
         min-height: 57px;
-
+      }
+      > li > a:focus {
+        display: block;
       }
       .selected {
         background-color: @gray-lighter;


### PR DESCRIPTION
When navigation "Services" or "Areas and district" -lists with tab for address, it doesn't show focus effect for list elements. This fixes it. It already had to correct css but didn't render it, because it was inline element. So changed the element to block.

### After

https://www.dropbox.com/s/bx9r04pxet82reb/Screenshot%202018-11-12%2014.41.09.png?dl=0