### PR TITLE
Fix skipped steps in Tour

### DIFF
--- a/src/views/feature-tour-start.coffee
+++ b/src/views/feature-tour-start.coffee
@@ -8,10 +8,12 @@ define (require) ->
         events:
             'click .close-button' : 'hideTour'
             'click .prompt-button' : 'showTour'
-        hideTour: (ev) ->
+        hideTour: (event) ->
             p13n.set 'hide_tour', true
             @trigger 'close'
-            ev.stopPropagation()
-        showTour: (ev) ->
+            event.stopPropagation()
+        showTour: (event) ->
+            event.preventDefault()
+            event.stopPropagation()
             tour.startTour()
             @trigger 'close'


### PR DESCRIPTION
- fix classname referred to in step 6
- add a new promise object for handling readiness state of step 7
- fetch all needed unit fields in step 7 to avoid re-fetch breaking the tour
- fix classname referred to in step 11
- fix needing to click the tour start button twice
- minor style fixes