### PR TITLE
Suggest addresses with numbers right away in search/travel guide

### DIFF
--- a/src/geocoding.coffee
+++ b/src/geocoding.coffee
@@ -25,7 +25,6 @@ define (require) ->
     GeocoderSourceBackend: class GeocoderSourceBackend
         constructor: (@options) ->
             _.extend @, Backbone.Events
-            @street = undefined
             geocoderStreetEngine = @_createGeocoderStreetEngine p13n.getLanguage()
             @geocoderStreetSource = geocoderStreetEngine.ttAdapter()
         setOptions: (@options) ->
@@ -37,16 +36,14 @@ define (require) ->
             e = new Bloodhound
                 name: 'street_suggestions'
                 remote:
-                    url: appSettings.service_map_backend + "/street/?page_size=4"
+                    url: appSettings.service_map_backend + "/search/?page_size=4&type=address"
                     replace: (url, query) =>
                         url += "&input=#{query}"
                         url += "&language=#{if lang != 'sv' then 'fi' else lang}"
                         url
                     ajax: settings.applyAjaxDefaults {}
                     filter: (parsedResponse) =>
-                        results = new models.StreetList parsedResponse.results
-                        if results.length == 1
-                            @setStreet results.first()
+                        results = new models.AddressList parsedResponse.results, {parse: true}
                         results.toArray()
                     rateLimitWait: 50
                 datumTokenizer: (datum) ->
@@ -57,109 +54,23 @@ define (require) ->
             return e
 
         typeaheadSelected: (ev, data) ->
-            objectType = data.object_type
-            if objectType == 'address'
-                if data instanceof models.Position
-                    @options.$inputEl.typeahead 'close'
-                    @options.selectionCallback ev, data
-                else
-                    @setStreet(data).done =>
-                        # To support IE on typeahead < v11, we need to call internal API
-                        # because typeahead listens to different events on IE compared to
-                        # web browsers.
-                        typeaheadInput = @options.$inputEl.data('ttTypeahead').input
-                        typeaheadInput.setInputValue @options.$inputEl.val() + ' '
-            else
-                @setStreet null
-
-        streetSelected: ->
-            unless @street?
-                return
-            _.defer =>
-                streetName = p13n.getTranslatedAttr @street.name
-                @options.$inputEl.typeahead('val', '')
-                @options.$inputEl.typeahead('val', streetName + ' ')
-                @options.$inputEl.trigger 'input'
-
-        setStreet: (street) =>
-            sm.withDeferred (deferred) =>
-                unless street?
-                    @street = undefined
-                    deferred.resolve()
-                    return
-                if street.get('id') == @street?.get('id')
-                    deferred.resolve()
-                    return
-                @street = street
-                @street.translatedName = (
-                    @street.get('name')[p13n.getLanguage()] or @street.get('name').fi
-                ).toLowerCase()
-                @street.addresses = new models.AddressList [], pageSize: 200
-                @street.addresses.comparator = (x) =>
-                    parseInt x.get('number')
-                @street.addressesFetched = false
-                @street.addresses.fetch
-                    data:
-                        street: @street.get('id')
-                    success: =>
-                        @street?.addressesFetched = true
-                        deferred.resolve()
-
-        addressSource: (query, callback) =>
-            # escape parentheses for regexp
-            streetName = @street.translatedName
-                .replace /([()])/g, '\\$1'
-            re = new RegExp "^\\s*#{streetName}(\\s+\\d.*)?", 'i'
-            matches = query.match re
-            if matches?
-                [q, numberPart] = matches
-                # TODO: automatically make this search on focus
-                unless numberPart?
-                    numberPart = ''
-                numberPart = numberPart.replace(/\s+/g, '').replace /[^0-9]+/g, ''
-                done = =>
-                    unless @street?
-                        callback []
-                        return
-                    if @street.addresses.length == 1
-                        callback @street.addresses.toArray()
-                        return
-                    filtered = @street.addresses
-                        .filter (a) =>
-                            a.humanNumber().indexOf(numberPart) == 0
-                    results = filtered.slice(0, 2)
-                    last = _(filtered).last()
-                    unless last in results
-                        if last?
-                            results.push last
-                    callback results
-                if @street.addressesFetched
-                    done()
-                else
-                    @listenToOnce @street.addresses, 'sync', =>
-                        done()
+            if data instanceof models.Position
+                @options.$inputEl.typeahead 'close'
+                @options.selectionCallback ev, data
 
         getSource: =>
-            (query, cb) =>
-                if @street? and @street.translatedName.length <= query.length
-                    @addressSource query, cb
-                else
-                    @geocoderStreetSource query, cb
+            (query, cb) => @geocoderStreetSource query, cb
 
         getDatasetOptions: =>
             name: 'address'
             displayKey: (c) ->
                 if c instanceof models.Position
                     c.humanAddress()
-                else if c instanceof models.Street
-                    c.getText 'name'
                 else
                     c
             source: @getSource()
             templates:
                 suggestion: (c) =>
-                    if c instanceof models.Position
-                        c.set 'street', @street
                     c.address = c.humanAddress()
                     c.object_type = 'address'
                     jade.template 'typeahead-suggestion', c

--- a/src/models.coffee
+++ b/src/models.coffee
@@ -567,9 +567,6 @@ define (require) ->
         getMunicipalityName: ->
             i18n.t "municipality.#{@get('municipality')}"
 
-    class StreetList extends SMCollection
-        model: Street
-
     class Position extends mixOf SMModel, GeoModel
         resourceName: 'address'
         origin: -> 'clicked'
@@ -578,7 +575,7 @@ define (require) ->
         parse: (response, options) ->
             data = super response, options
             street = data.street
-            if street
+            if not (street instanceof Street)
                 data.street = new Street street
             data
         isDetectedLocation: ->
@@ -664,6 +661,8 @@ define (require) ->
 
     class AddressList extends SMCollection
         model: Position
+        parse: (response, options) ->
+            response.map(Position::parse)
 
     class CoordinatePosition extends Position
         origin: ->
@@ -1088,7 +1087,6 @@ define (require) ->
         FeedbackList: FeedbackList
         FeedbackMessage: FeedbackMessage
         Street: Street
-        StreetList: StreetList
 
     # Expose models to browser console to aid in debugging
     window.models = exports

--- a/src/search.coffee
+++ b/src/search.coffee
@@ -9,7 +9,7 @@ define (require) ->
     servicemapEngine = new Bloodhound
         name: 'suggestions'
         remote:
-            url: appSettings.service_map_backend + "/search/?language=#{lang}&type=unit,service,street&page_size=4&input="
+            url: appSettings.service_map_backend + "/search/?language=#{lang}&type=unit,service&page_size=4&input="
             replace: (url, query) =>
                 url += query
                 cities = p13n.getCities()


### PR DESCRIPTION
Now we provide addresses with numbers as a suggestion in search/travel guide right away. 

This fixes few usability issues that existed: 1) User couldn't paste a full address with number to input field and get a suggestion (e.g. Tehtaankatu 12) 2) When user edited a previously selected address in travel guide, user needed to remove the number part fully from the address to get suggestions. 

### Before 

https://www.dropbox.com/s/nfwvfv3jd9fmcm8/Screenshot%202018-11-16%2008.56.49.png?dl=0

### After

https://www.dropbox.com/s/nfwvfv3jd9fmcm8/Screenshot%202018-11-16%2008.56.49.png?dl=0