### PR TITLE
Fix focus indicator for personalisation selections for IE 11

### DIFF
--- a/styles/personalisation.less
+++ b/styles/personalisation.less
@@ -20,7 +20,7 @@
         text-shadow: @white-glow;
 
         span {
-          display: inline-block;
+          display: block;
           background-color: @white;
           border-radius: 50%;
           width: 40px;
@@ -281,7 +281,7 @@
     }
 
     span {
-      display: inline-block;
+      display: block;
       white-space: normal;
     }
 

--- a/views/templates/mixins/personalisation-mode.jade
+++ b/views/templates/mixins/personalisation-mode.jade
@@ -10,4 +10,4 @@ mixin renderMode(group, type, icon, activeViewpoints, preferredTabindex)
         span.text(id=label)
           != uppercaseFirst(t("personalisation." + type))
         if selected
-          span.icon-icon-checked
+          span


### PR DESCRIPTION
Few fixes were made:
1) Fixed focus outline visual bug with selected personalisation settings that occured with IE 11 (https://www.dropbox.com/s/h7cr6556uooegex/Screenshot%202018-12-17%2011.15.16.png?dl=0)
2) Removed unnecessary checked icons from travel guide