### PR TITLE
Fix/travel guide location lockup

### DIFF
--- a/locales/app.yaml
+++ b/locales/app.yaml
@@ -397,7 +397,7 @@ transit:
         current_location: Current location
         location_pending: Detecting location
         user_picked_location: User picked location
-        location_forbidden: Access to location denied
+        location_not_available: Location not available
         use_current_location: Use my current location
         depart: Depart
         arrive: Arrive
@@ -436,7 +436,7 @@ transit:
         current_location: Nykyinen sijaintini
         location_pending: Haetaan sijaintia
         user_picked_location: Poimittu sijainti
-        location_forbidden: Sijainnin haku ei ole sallittu
+        location_not_available: Sijainti ei ole saatavilla
         use_current_location: Käytä nykyistä sijaintiani
         depart: Lähtöaika
         arrive: Perillä
@@ -492,7 +492,7 @@ transit:
         current_location: Min nuvarande position
         location_pending: Söker position
         user_picked_location: Position inhämtad
-        location_forbidden: Platsinfo får inte hämtas
+        location_not_available: Platsinfo kan inte hämtas
         use_current_location: Använd min nuvarande position
         wait: Väntan
         at_destination: framme

--- a/src/models.coffee
+++ b/src/models.coffee
@@ -806,8 +806,8 @@ define (require) ->
                     return i18n.t('transit.current_location')
                 else if object.isPending()
                     return ''
-                else if object.isRejected()
-                    return i18n.t('transit.location_forbidden')
+                else if object.isFailed()
+                    return i18n.t('transit.location_not_available')
                 else
                     return object.humanAddress()
             else if object instanceof Unit

--- a/src/models.coffee
+++ b/src/models.coffee
@@ -673,17 +673,17 @@ define (require) ->
         initialize: (attrs) ->
             @isDetected = if attrs?.isDetected? then attrs.isDetected else false
             @pending = if attrs?.isPending? then attrs.isPending else true
-            @rejected = if attrs?.isRejected? then attrs.isRejected else false
+            @failed = if attrs?.isFailed? then attrs.isFailed else false
         isDetectedLocation: ->
             @isDetected
         isPending: ->
             @pending
-        isRejected: ->
-            @rejected
+        isFailed: ->
+            @failed
         setPending: (value) ->
             @pending = value
-        setRejected: (value) ->
-            @rejected = value
+        setFailed: (value) ->
+            @failed = value
             @pending = false
         setDetected: (value) ->
             @isDetected = value
@@ -824,11 +824,11 @@ define (require) ->
                     if endpoint.isPending()
                         return false
             true
-        isRejected: ->
+        isFailed: ->
             for endpoint in @get 'endpoints'
                 unless endpoint? then return false
                 if endpoint instanceof CoordinatePosition
-                    if endpoint.isRejected()
+                    if endpoint.isFailed()
                         return true
             false
         ensureUnitDestination: ->

--- a/src/p13n.coffee
+++ b/src/p13n.coffee
@@ -178,9 +178,10 @@ define (require) ->
             catch e
                 return false
 
-        _handleLocation: (pos, positionObject) =>
+        _handleLocation: (pos, positionObject, successCallback, failureCallback) =>
             if pos.coords.accuracy > 10000
                 @trigger 'position_error'
+                failureCallback?()
                 return
             unless positionObject?
                 positionObject = new models.CoordinatePosition { isDetected: true, isPending: false }
@@ -193,6 +194,7 @@ define (require) ->
                 @trigger 'position', positionObject
                 if not @get 'location_requested'
                     @set 'location_requested', true
+                successCallback?()
             if appSettings.user_location_delayed
                 setTimeout cb, 3000
             else
@@ -379,12 +381,11 @@ define (require) ->
                 enableHighAccuracy: false
                 timeout: 30000
             navigator.geolocation.getCurrentPosition ((pos) =>
-                @_handleLocation(pos, positionModel)
-                successCallback?()
+                @_handleLocation(pos, positionModel, successCallback, failureCallback)
             ),  () =>
-                failureCallback?()
                 @trigger 'position_error'
                 @set 'location_requested', false
+                failureCallback?()
             , posOpts
 
         set: (attr, val) ->

--- a/src/views/route-settings.coffee
+++ b/src/views/route-settings.coffee
@@ -215,7 +215,7 @@ define (require) ->
                 position.setDetected(true)
                 @applyChanges()
             ,() =>
-                position.setRejected(true)
+                position.setFailed(true)
                 @applyChanges()
 
         detectCurrentLocation: (event) ->

--- a/src/views/route.coffee
+++ b/src/views/route.coffee
@@ -99,7 +99,7 @@ define (require) ->
                     @routeSettingsRegion.currentView.updateRegions()
                     @requestRoute()
                 ,() =>
-                    @routingParameters.getOrigin().setRejected(true)
+                    @routingParameters.getOrigin().setFailed(true)
                     @routeSettingsRegion.currentView.updateRegions()
 
             @routeSettingsRegion.show new RouteSettingsView
@@ -113,7 +113,7 @@ define (require) ->
                 noRoute: !route?
 
         requestRoute: ->
-            if @routingParameters.isRejected()
+            if @routingParameters.isFailed()
                 @cancelToken?.cancel()
                 return
             else if not @routingParameters.isComplete()


### PR DESCRIPTION
Travel guide sometimes sends request to HSL containing null value for paramater `from`. This occurs when detected location has bad accuracy for location. This fix handles also that scenario.