### PR TITLE
Fix/accessibility navigation improvements

### DIFF
--- a/src/views/navigation.coffee
+++ b/src/views/navigation.coffee
@@ -197,10 +197,11 @@ define (require) ->
                         collection: new models.UnitList()
 
                 when 'search'
-                    view = new SearchResultsSummaryLayout
-                        collection: @searchResults
-                    if opts?.disableAutoFocus
-                        view.disableAutoFocus()
+                    if @searchResults.length > 0
+                        view = new SearchResultsSummaryLayout
+                            collection: @searchResults
+                        if opts?.disableAutoFocus
+                            view.disableAutoFocus()
                 when 'service-node-units'
                     view = new UnitListingView
                         model: new Backbone.Model

--- a/src/views/personalisation.coffee
+++ b/src/views/personalisation.coffee
@@ -47,18 +47,46 @@ define (require) ->
                 @setActivations()
                 @renderIconsForSelectedModes()
             @listenTo p13n, 'user:open', -> @personalisationButtonClick()
+            # These selectors are used when closing the personalisation menu to regain focus in relevant page section
+            @focusAfterCloseMenu = null
+            @focusAfterCloseMenuBackup = null
 
         serializeData: ->
             lang: p13n.getLanguage()
 
+        _getSelector: ($element) ->
+          selector = ""
+          id = $element.attr("id")
+          if id
+            selector += "#"+ id
+
+          classNames = $element.attr("class")
+          if classNames
+            selector += "." + $.trim(classNames).replace(/\s/gi, ".")
+          selector
+
+        _findBackupParentLink: ($element) ->
+            # We assume that user has opened personalisation menu from one of the
+            # collapsed sections so as a backup focus element we pick first link inside section.
+            $element.parents('.section').find('a').first()
+
         personalisationButtonClick: (ev) ->
             ev?.preventDefault()
+            @focusAfterCloseMenu = @_getSelector $(document.activeElement)
+            @focusAfterCloseMenuBackup = @_getSelector @_findBackupParentLink($(document.activeElement))
             unless $('#personalisation').hasClass('open')
                 @toggleMenu(ev)
+                # When opening the menu, focus on the first of the menu
+                $('.personalisation-content a').first().focus()
 
         toggleMenu: (ev) ->
             ev?.preventDefault()
             $('#personalisation').toggleClass('open')
+            unless $('#personalisation').hasClass('open')
+                elementToFocusAfterClose = if $(@focusAfterCloseMenu).length > 0 then $(@focusAfterCloseMenu) else $(@focusAfterCloseMenuBackup)
+                elementToFocusAfterClose.focus()
+                @focusAfterCloseMenu = null
+                @focusAfterCloseMenuBackup = null
 
         openMenuFromMessage: (ev) ->
             ev?.preventDefault()


### PR DESCRIPTION
Fixed two issues in general navigation:

1) When having unit detail open in sidebar and if you click on the search bar input field, the sidebar closes. This can be surprising (and annoying) so keep it open unless use actually searches for something.

2) When in sidebar content there is a link to personalisation settings, it is basically impossible for the user to jump to settings and then back. So created JQuery based logic where the active element selector in the sidebar is saved when opening the settings, and the focus returned there when settings is closed. 

Also a backup parent selector is stored in case we are dealing with a sidebar link that disappears when any personalisation settings is set.