### PR TITLE
Fix/personalisation ui fixes

### DIFF
--- a/src/views/route-settings.coffee
+++ b/src/views/route-settings.coffee
@@ -275,11 +275,13 @@ define (require) ->
             event.preventDefault()
             type = $(event.target).closest('li').data 'type'
             p13n.toggleTransport type
+            @render()
 
         switchTransportDetails: (event, group) ->
             event.preventDefault()
             type = $(event.target).closest('li').data 'type'
             p13n.toggleTransportDetails group, type
+            @render()
 
     class RouteControllersView extends base.SMItemView
         template: 'route-controllers'

--- a/styles/personalisation.less
+++ b/styles/personalisation.less
@@ -281,7 +281,7 @@
     }
 
     span {
-      display: inline-block;
+      display: block;
       white-space: normal;
     }
 

--- a/views/templates/mixins/personalisation-mode.jade
+++ b/views/templates/mixins/personalisation-mode.jade
@@ -10,4 +10,4 @@ mixin renderMode(group, type, icon, activeViewpoints, preferredTabindex)
         span.text(id=label)
           != uppercaseFirst(t("personalisation." + type))
         if selected
-          span.icon-icon-checked
+          span


### PR DESCRIPTION
- Fixed broken selected personalisation outline with IE 11
- Removed unnecessary checked icon in travel guide settings
- Fixed ie 11 non-render issue with travel guide settings concerning vehicle types changes