### PR TITLE
Fix/keyboard accessibility

### DIFF
--- a/src/views/details.coffee
+++ b/src/views/details.coffee
@@ -9,7 +9,7 @@ define (require) ->
         className: 'navigation-element'
         regions:
             'routeRegion': '.section.route-section'
-        events:
+        events: 
             'click .collapse-button': 'toggleCollapse'
             'click .map-active-area': 'showMap'
             'click .mobile-header': 'showContent'

--- a/src/views/new-search-results.coffee
+++ b/src/views/new-search-results.coffee
@@ -183,17 +183,6 @@ define (require) ->
             window.c = @collection
             @expansion = @expansion + PAGE_SIZE
 
-        _getSelector: ($element) ->
-          selector = ""
-          id = $element.attr("id")
-          if id
-            selector += "#"+ id
-
-          classNames = $element.attr("class")
-          if classNames
-            selector += "." + $.trim(classNames).replace(/\s/gi, ".")
-          selector
-
     class MoreButton extends base.SMItemView
         tagName: 'a'
         className: 'show-prompt show-all'

--- a/src/views/new-search-results.coffee
+++ b/src/views/new-search-results.coffee
@@ -147,6 +147,8 @@ define (require) ->
                     p13n.requestLocation()
                     return
             executeComparator()
+            ## Return focus after sorting
+            $( "#sorting-dropdown" ).focus()
         serializeData: ->
             if @hidden or not @collection?
                 return hidden: true
@@ -180,6 +182,17 @@ define (require) ->
             @collection.add @fullCollection.slice(@expansion, @expansion + PAGE_SIZE)
             window.c = @collection
             @expansion = @expansion + PAGE_SIZE
+
+        _getSelector: ($element) ->
+          selector = ""
+          id = $element.attr("id")
+          if id
+            selector += "#"+ id
+
+          classNames = $element.attr("class")
+          if classNames
+            selector += "." + $.trim(classNames).replace(/\s/gi, ".")
+          selector
 
     class MoreButton extends base.SMItemView
         tagName: 'a'

--- a/src/views/service-cart.coffee
+++ b/src/views/service-cart.coffee
@@ -12,6 +12,7 @@ define (require) ->
             'click .maximizer': 'maximize'
             'keydown .maximizer': @keyboardHandler @maximize, ['space', 'enter']
             'click .cart-close-button': 'minimize'
+            'keydown .cart-close-button': @keyboardHandler @minimize, ['space', 'enter']
             'click .remove-service': 'removeServiceItem'
             'keydown .remove-service': @keyboardHandler @removeServiceItem, ['space', 'enter']
             'click .map-layer input': 'selectLayerInput'

--- a/src/views/unit-details.coffee
+++ b/src/views/unit-details.coffee
@@ -38,10 +38,12 @@ define (require) ->
             'show.bs.collapse': 'scrollToExpandedSection'
             'hide.bs.collapse': '_removeLocationHash'
             'click .send-feedback': '_onClickSendFeedback'
+            
         type: 'details'
         constructor: (args...) ->
             _.extend(this.events, DetailsView.prototype.events);
             _.extend(this.regions, DetailsView.prototype.regions);
+            @events['keydown .icon-icon-close'] = @keyboardHandler @userClose, ['space', 'enter']
             super(args...)
         initialize: (options) ->
             super(options)
@@ -118,6 +120,8 @@ define (require) ->
             @resourceReservationRegion.show view
 
             app.vent.trigger 'site-title:change', @model.get('name')
+            console.log $('.content')
+            $('.content').focus()
 
         onDomRefresh: ->
             @_attachMobileHeaderListeners()

--- a/src/views/unit-details.coffee
+++ b/src/views/unit-details.coffee
@@ -120,7 +120,6 @@ define (require) ->
             @resourceReservationRegion.show view
 
             app.vent.trigger 'site-title:change', @model.get('name')
-            console.log $('.content')
             $('.content').focus()
 
         onDomRefresh: ->

--- a/views/templates/details.jade
+++ b/views/templates/details.jade
@@ -34,7 +34,7 @@ mixin renderConnection(conn)
       h2
         span= name
 
-.content.limit-max-height
+.content.limit-max-height(tabindex="-1")
   .map-active-area
   .details-view-area
   if picture_url
@@ -47,7 +47,7 @@ mixin renderConnection(conn)
   .section.main-info
     .header
       canvas#details-marker-canvas(width="30", height="30")
-      span.icon-icon-close
+      a.icon-icon-close(href="#")
       h2
         span= name
 
@@ -138,7 +138,7 @@ mixin renderConnection(conn)
       if services
         div.service
           for service in services
-            a.service-link(href="#" role="service-link" data-id=service.id)
+            a.service-link(href="#" role="service-link" data-id=service.id) 
               span(class="service-node-background-color-#{service.color}" class="service-bullet")
               | &nbsp;
               = tAttr(service.name)

--- a/views/templates/feature-tour-start.jade
+++ b/views/templates/feature-tour-start.jade
@@ -1,2 +1,2 @@
-a(href="#", tabindex="1" class="prompt-button")!= t('tour.start_prompt')
+a(href="#", class="prompt-button")!= t('tour.start_prompt')
   span.close-button.icon.icon-icon-close

--- a/views/templates/language-selector.jade
+++ b/views/templates/language-selector.jade
@@ -2,5 +2,5 @@
 each item, index in items
   if index > 0
     span.separator= ' | '
-  a.external-link.language(href=item.link data-language!=item.code, tabindex="1")
+  a.external-link.language(href=item.link data-language!=item.code)
     = item.name

--- a/views/templates/location-refresh-button.jade
+++ b/views/templates/location-refresh-button.jade
@@ -1,3 +1,3 @@
 .location-refresh-header.sm-control-button-wrapper
-  a.sm-control-button.location-button(href='#!', role="button", tabindex="1")
+  a.sm-control-button.location-button(href='#!', role="button")
     span.icon-icon-you-are-here

--- a/views/templates/measure-close-button.jade
+++ b/views/templates/measure-close-button.jade
@@ -1,4 +1,4 @@
 .sm-control-button-wrapper
-  a.sm-control-button.measure-close-button(href='#!', role="button", tabindex="1")
+  a.sm-control-button.measure-close-button(href='#!', role="button")
     span.icon-icon-measuring-tool
     span.measure-close-text #{closeText}

--- a/views/templates/mixins/personalisation-mode.jade
+++ b/views/templates/mixins/personalisation-mode.jade
@@ -1,5 +1,5 @@
 mixin renderMode(group, type, icon, activeViewpoints, preferredTabindex)
-  - tabindex = preferredTabindex !== undefined ? preferredTabindex : '1'
+  - tabindex = preferredTabindex !== undefined ? preferredTabindex : '0'
   - label = "label-" + group + "-" + type
   - selected = activeViewpoints.indexOf(type) != -1
   li(data-group=group, data-type=type class=(selected ? 'selected' : ''))

--- a/views/templates/navigation-header.jade
+++ b/views/templates/navigation-header.jade
@@ -3,4 +3,4 @@ h2.sr-only
 .search-container
   #search-region.header.search(role="link", data-type="search", tabindex="-1")
 .browse-container
-  #browse-region.header.browse(role="link", data-type="browse", tabindex="1")
+  #browse-region.header.browse(role="link", data-type="browse", tabindex="0")

--- a/views/templates/navigation-search.jade
+++ b/views/templates/navigation-search.jade
@@ -3,6 +3,6 @@ h3.sr-only
   != t('assistive.search')
 form.input-container
   - value = input_query !== undefined ? input_query : ''
-  input.form-control(type="search", placeholder!=t('sidebar.search'), title!=t('sidebar.search'), value!=value tabindex="1")
+  input.form-control(type="search", placeholder!=t('sidebar.search'), title!=t('sidebar.search'), value!=value)
   span.action-button.close-button(type="button")
     span.icon-icon-close

--- a/views/templates/new-search-results.jade
+++ b/views/templates/new-search-results.jade
@@ -5,8 +5,7 @@ if !hidden
     div.header-item.expanded-search-results
       div.header-column-main
         if !onlyResultType
-          a.back-button(href="#", role="button", tabindex="0")
-            span.icon-icon-back-bold
+          a.back-button.icon-icon-back-bold(href="#", role="button")
         span.breadcrumbs
           .crumb
             = crumb
@@ -17,7 +16,7 @@ if !hidden
         if !collapsed
           label.sorting-label
             = t('search.sort_label')
-          a(id="sorting-dropdown", class="sorting", data-toggle="dropdown", role="button", aria-haspopup="true", aria-expanded="false")
+          a(id="sorting-dropdown", class="sorting", data-toggle="dropdown", role="button", aria-haspopup="true", aria-expanded="false", tabindex="0")
             != t('search.sort.' + comparatorKey)
           ul(class="dropdown-menu sorting-dropdown", aria-labelledby="sorting-dropdown")
             each comparatorKey in comparatorKeys

--- a/views/templates/personalisation.jade
+++ b/views/templates/personalisation.jade
@@ -2,7 +2,7 @@
 mixin renderCity(id)
   - label = "label-municipality-" + id
   li(data-group='city', data-type=id)
-    a(href="#", role="button", aria-described-by=label, tabindex="1")
+    a(href="#", role="button", aria-described-by=label)
       .icon
         span(class!="icon-icon-coat-of-arms-#{id}")
       span.text(id=label)
@@ -10,16 +10,16 @@ mixin renderCity(id)
 mixin renderLanguage(code, name)
   - label = "label-language-" + code
   li(data-group='language', data-type=code, class='selected')
-    a(href="#", role="button", aria-described-by=label, tabindex="1")
+    a(href="#", role="button", aria-described-by=label)
       span.text(id=label)
         = name
 
 
 .personalisation-header
-  a.personalisation-button(href="#", role="button", tabindex="1")
+  a.personalisation-button(href="#", role="button")
     img.icon.icon-personalise(src=staticPath('icons/accessibility-person-circled.svg') alt=t('personalisation.personalise'))
     h2.text= t('personalisation.personalise')
-  a.ok-button(href="#", role="button", tabindex="1")
+  a.ok-button(href="#", role="button")
     | OK
   .selected-personalisations
 .personalisation-content

--- a/views/templates/search-results.jade
+++ b/views/templates/search-results.jade
@@ -5,8 +5,8 @@ if !hidden
     div.header-item.expanded-search-results
       div.header-column-main
         if !onlyResultType
-          a.back-button(href="#", role="button", tabindex="0")
-            span.icon-icon-back-bold
+          a.back-button(href="#", role="button")
+            span.icon-icon-back-bold(tabindex="0")
         span.breadcrumbs
           .crumb
             = crumb
@@ -17,7 +17,7 @@ if !hidden
         if !collapsed
           label.sorting-label
             = t('search.sort_label')
-          a(id="sorting-dropdown", class="sorting", data-toggle="dropdown", role="button", aria-haspopup="true", aria-expanded="false")
+          a(id="sorting-dropdown", class="sorting", data-toggle="dropdown", role="button", aria-haspopup="true", aria-expanded="false", tabindex="0")
             != t('search.sort.' + comparatorKey)
           ul(class="dropdown-menu sorting-dropdown", aria-labelledby="sorting-dropdown")
             each comparatorKey in comparatorKeys

--- a/views/templates/service-cart.jade
+++ b/views/templates/service-cart.jade
@@ -1,6 +1,6 @@
 if minimized
   li.personalisation-container
-    a.maximizer(tabindex="1", role="button")
+    a.maximizer(role="button", tabindex="0")
       span.icon-icon-map-options
       h2.sr-only= t('service_cart.currently_on_map')
   each item in items
@@ -12,7 +12,7 @@ else
     span.layer-icon.icon-icon-map-options
     h2= t('service_cart.currently_on_map')
       span.button.cart-close-button
-        span.icon-icon-close
+        span.icon-icon-close(tabindex="0")
   li.map-layer
     div.map-layers
       span.layer-icon.icon-icon-map-options
@@ -131,6 +131,6 @@ else
         div(class="color-ball service-node-background-color-#{item.color}")
         div.service-node-name
           = item.name
-      a.button.remove-service(role="button", data-service="#{item.id}", data-type="#{item.type}", tabindex="1")
+      a.button.remove-service(role="button", data-service="#{item.id}", data-type="#{item.type}")
         span.icon-icon-close
         span.sr-only= t('general.remove')

--- a/views/templates/tool-menu.jade
+++ b/views/templates/tool-menu.jade
@@ -1,5 +1,5 @@
 .tool-header.sm-control-button-wrapper.hidden-xs
   #tool-context.context-menu
-  a.sm-control-button(href="#", role="button", tabindex="1")
+  a.sm-control-button(href="#", role="button")
     span
       i.icon-icon-tools


### PR DESCRIPTION
- Removed positive tabindexes to improve browsing with keyboard
- Improved focus after searching for unit: the details of the unit are now easier to browse with keyboard
- Made it possible to reach the sorting dropdown-button in unit list with keyboard
- Fixed the focus error after changing the sorting order of the list (focus is now moved back to the content instead of disappearing)
- Added the closing button in unit details -page and servicecart to be accessible with keyboard only and added keydown-event (pressing enter or space activates the button)