### PR TITLE
Add better back button functionality to unit list

### DIFF
--- a/src/views/navigation.coffee
+++ b/src/views/navigation.coffee
@@ -212,6 +212,8 @@ define (require) ->
                         selectedServiceNodes: @selectedServiceNodes
                         collection: new models.UnitList()
                         fullCollection: @units
+                    @listenTo view, 'close', =>
+                        @.change 'browse'
                 when 'details'
                     view = new UnitDetailsView
                         model: @selectedUnits.first()

--- a/src/views/new-search-results.coffee
+++ b/src/views/new-search-results.coffee
@@ -212,6 +212,7 @@ define (require) ->
                 @unitListRegion.empty()
                 if @model.get 'position'
                     app.request 'clearRadiusFilter'
+                @trigger 'close'
             if @model.get('collectionType') == 'radius'
                 @controls.show new RadiusControlsView radius: @fullCollection.filters.distance
 


### PR DESCRIPTION
Fixed the navigation when going from unit list back to all services.
Added trigger "close" to unit-list back button and made navigation listen to it and reopen the all services menu.