### PR TITLE
Fix/show only transits on high zoom

### DIFF
--- a/src/app-state.coffee
+++ b/src/app-state.coffee
@@ -11,6 +11,7 @@ define (require) ->
             @selectedServices = new models.ServiceList()
             @selectedServiceNodes = new models.ServiceNodeList()
             @units = new models.UnitList null, setComparator: true
+            @stopUnits = new models.UnitList null, setComparator: true
             @selectedUnits = new models.UnitList()
             @selectedEvents = new models.EventList()
             @searchResults = new models.SearchList [], pageSize: appSettings.page_size

--- a/src/app.coffee
+++ b/src/app.coffee
@@ -290,6 +290,7 @@ define (require) ->
                 searchResults: appModels.searchResults
                 selectedPosition: appModels.selectedPosition
                 selectedDivision: appModels.selectedDivision
+                stopUnits: appModels.stopUnits
                 route: appModels.route
                 divisions: appModels.divisions
                 dataLayers: appModels.dataLayers
@@ -423,6 +424,7 @@ define (require) ->
             "setUnits"
             "setUnit"
             "addUnitsWithinBoundingBoxes"
+            "addStopUnitsWithinBoundingBoxes"
 
             "activateMeasuringTool"
             "deactivateMeasuringTool"

--- a/src/map-base-view.coffee
+++ b/src/map-base-view.coffee
@@ -46,6 +46,7 @@ define (require) ->
             @markers = {}
             @geometries = {}
             @units = @opts.units
+            @stopUnits = @opts.stopUnits
             @transportationStops = @opts.transportationStops
             @selectedUnits = @opts.selectedUnits
             @selectedPosition = @opts.selectedPosition
@@ -58,6 +59,10 @@ define (require) ->
                 # Triggered when all of the
                 # pages of units have been fetched.
                 @drawUnits @units, options
+                if @selectedUnits.isSet()
+                    @highlightSelectedUnit @selectedUnits.first()
+            @listenTo @stopUnits, 'finished', (options) =>
+                @drawUnits @stopUnits, options, 'stopUnitMarkers'
                 if @selectedUnits.isSet()
                     @highlightSelectedUnit @selectedUnits.first()
 
@@ -84,6 +89,8 @@ define (require) ->
             @map.on 'click', _.bind(@onMapClicked, @)
             @allMarkers = @getFeatureGroup()
             @allMarkers.addTo @map
+            @stopUnitMarkers = @getFeatureGroup()
+            @stopUnitMarkers.addTo @map
             @allGeometries = L.featureGroup()
             @allGeometries.addTo @map
             @divisionLayer = L.featureGroup()
@@ -187,11 +194,9 @@ define (require) ->
                     @divisionLayer.clearLayers()
                     @drawDivisions @divisions
 
-        drawUnits: (units, options) ->
+        drawUnits: (units, options, layer) ->
             cancelled = false
             options?.cancelToken?.addHandler -> cancelled = true
-
-            @allMarkers.clearLayers()
             @allGeometries.clearLayers()
 
             if units.filters?.bbox?
@@ -199,6 +204,8 @@ define (require) ->
                     return
 
             unitsWithLocation = units.filter (unit) => unit.get('location')?
+            if !layer?
+                unitsWithLocation = unitsWithLocation.filter (unit) => !@isSubwayStation(unit)
             markers = unitsWithLocation.map (unit) => @createMarker(unit, options?.marker)
 
             unitHasGeometry = (unit) ->
@@ -218,7 +225,18 @@ define (require) ->
             if units.length == 1
                 @highlightSelectedUnit units.first()
 
-            @allMarkers.addLayers markers
+            if layer?
+                @[layer].clearLayers()
+                @[layer] = @getFeatureGroup()
+                @[layer].addLayers markers
+                @[layer].addTo @map
+            else
+                @allMarkers.clearLayers()
+                @allMarkers = @getFeatureGroup()
+                @allMarkers.addLayers markers
+                @allMarkers.addTo @map
+            
+
 
         # Prominently highlight the marker whose details are being
         # examined by the user.

--- a/src/map-base-view.coffee
+++ b/src/map-base-view.coffee
@@ -62,9 +62,7 @@ define (require) ->
                 if @selectedUnits.isSet()
                     @highlightSelectedUnit @selectedUnits.first()
             @listenTo @stopUnits, 'finished', (options) =>
-                @drawUnits @stopUnits, options, 'stopUnitMarkers'
-                if @selectedUnits.isSet()
-                    @highlightSelectedUnit @selectedUnits.first()
+                @drawUnits @stopUnits, options, 'stopUnitMarkers', hideSubways = false
 
         getProxy: ->
             fn = => map.MapUtils.overlappingBoundingBoxes @map
@@ -194,7 +192,7 @@ define (require) ->
                     @divisionLayer.clearLayers()
                     @drawDivisions @divisions
 
-        drawUnits: (units, options, layer) ->
+        drawUnits: (units, options, layer, hideSubways = true) ->
             cancelled = false
             options?.cancelToken?.addHandler -> cancelled = true
             @allGeometries.clearLayers()
@@ -204,7 +202,7 @@ define (require) ->
                     return
 
             unitsWithLocation = units.filter (unit) => unit.get('location')?
-            if !layer?
+            if hideSubways
                 unitsWithLocation = unitsWithLocation.filter (unit) => !@isSubwayStation(unit)
             markers = unitsWithLocation.map (unit) => @createMarker(unit, options?.marker)
 

--- a/src/map-view.coffee
+++ b/src/map-view.coffee
@@ -250,7 +250,7 @@ define (require) ->
             unless @selectedUnits.isEmpty()
                 @highlightSelectedUnit @selectedUnits.first()
             if @units.isEmpty()
-                @showAllUnitsAtHighZoom()
+                @showAllStopUnitsAtHighZoom()
 
         removeUnit: (unit, units, options) ->
             if unit.marker?
@@ -531,7 +531,7 @@ define (require) ->
                 if @skipMoveend
                     @skipMoveend = false
                     return
-                @showAllUnitsAtHighZoom()
+                @showAllStopUnitsAtHighZoom()
                 @updatePublicTransitStops()
 
         postInitialize: ->
@@ -603,19 +603,9 @@ define (require) ->
         updatePublicTransitStopUnits: (bboxes, level) ->
             app.request 'addStopUnitsWithinBoundingBoxes', bboxes, level
 
-        showAllUnitsAtHighZoom: ->
+        showAllStopUnitsAtHighZoom: ->
             if @map.getZoom() < map.MapUtils.getZoomlevelToShowAllMarkers()
                 @previousBoundingBoxes = null
-                return
-            if not @stopUnitsOnlyOnZoom() and getIeVersion()
-                return
-            if @selectedUnits.isSet() and not @selectedUnits.first().collection?.filters?.bbox?
-                return
-            if @selectedServices.isSet()
-                return
-            if @selectedServiceNodes.isSet()
-                return
-            if @searchResults.isSet()
                 return
 
             transformedBounds = map.MapUtils.overlappingBoundingBoxes @map

--- a/src/map-view.coffee
+++ b/src/map-view.coffee
@@ -455,6 +455,9 @@ define (require) ->
             @publicTransitStopsLayer.clearLayers()
             @publicTransitStopsCache = {}
 
+        clearPublicTransitStopUnitsLayer: ->
+            @stopUnitMarkers.clearLayers()
+
         addMapActiveArea: ->
             @map.setActiveArea 'active-area'
             MapView.setMapActiveAreaMaxHeight
@@ -589,17 +592,22 @@ define (require) ->
             if zoom < zoomLimit
                 @clearPublicTransitStopsLayer()
                 @transitStops.reset()
+                @clearPublicTransitStopUnitsLayer()
+                @stopUnits.reset()
 
         updatePublicTransitStops: ->
             if @map.getZoom() < map.MapUtils.getZoomlevelToShowPublicTransitStops()
                 return
             app.request 'requestPublicTransitStops'
 
+        updatePublicTransitStopUnits: (bboxes, level) ->
+            app.request 'addStopUnitsWithinBoundingBoxes', bboxes, level
+
         showAllUnitsAtHighZoom: ->
             if @map.getZoom() < map.MapUtils.getZoomlevelToShowAllMarkers()
                 @previousBoundingBoxes = null
                 return
-            if getIeVersion()
+            if not @stopUnitsOnlyOnZoom() and getIeVersion()
                 return
             if @selectedUnits.isSet() and not @selectedUnits.first().collection?.filters?.bbox?
                 return
@@ -623,7 +631,7 @@ define (require) ->
                 level = @mapOpts.level
                 delete @mapOpts.level
 
-            app.request 'addUnitsWithinBoundingBoxes', bboxes, level
+            @updatePublicTransitStopUnits bboxes, level
 
         print: ->
             @printer.printMap true
@@ -663,5 +671,9 @@ define (require) ->
 
         needsSubwayIcon: (unit) ->
             @isSubwayStation unit
+
+        # Setting for getting stops only on high zoom
+        stopUnitsOnlyOnZoom: ->
+            return true
 
     MapView

--- a/src/map-view.coffee
+++ b/src/map-view.coffee
@@ -662,8 +662,4 @@ define (require) ->
         needsSubwayIcon: (unit) ->
             @isSubwayStation unit
 
-        # Setting for getting stops only on high zoom
-        stopUnitsOnlyOnZoom: ->
-            return true
-
     MapView


### PR DESCRIPTION
- Added new stopUnits list for subway transit stops and appropriate functionality to get data
- Hide subway entrances by default on unit drawing