### PR TITLE
Add descriptive text to elements for screen readers

### DIFF
--- a/locales/app.yaml
+++ b/locales/app.yaml
@@ -146,14 +146,17 @@ sidebar:
         and: and
         browse: All services
         browse_short: All
+        browse_button: open all services menu
         slogan: Your city, your services
         disclaimer: This is a beta version of the upcoming Helsinki area servicemap.
         search: Search
+        close_search: close search
         show: Show
         show_tooltip: Show on map
         hide_tooltip: Remove from map
         hide: Hide
         browse_tip: Click on title to show subtopics, or click 'show' to view services on the map.
+        close_details: close service point details window
         back_to:
             search: Back to results
             browse: Back to services
@@ -164,6 +167,8 @@ sidebar:
             "104": State service
             "105": Private service
         picture_of: Picture of
+        phone: call telephone number
+        browse_category: browse other srvice points of this category
         route_here: Route here
         hours: Opening hours
         website: Web site
@@ -192,14 +197,17 @@ sidebar:
         and: ja
         browse: Kaikki palvelut
         browse_short: Kaikki
+        browse_button: avaa kaikki palvelut valikko
         slogan: Sinun kaupunkisi, sinun palvelusi
         disclaimer: Tämä on pääkaupunkiseudun uudistuvan palvelukartan beta-versio.
         search: Hae
+        close_search: sulje haku
         show: Näytä
         show_tooltip: Näytä kartalla
         hide_tooltip: Poista kartalta
         hide: Piilota
         browse_tip: Klikkaa otsikosta näyttääksesi alipalvelut tai paina 'näytä', jos haluat nähdä palvelut kartalla.
+        close_details: sulje toimpisteen tideot ikkuna
         back_to:
             search: Takaisin hakutuloksiin
             browse: Takaisin palveluihin
@@ -210,6 +218,8 @@ sidebar:
             "104": Valtion palvelu
             "105": Yksityinen palvelu
         picture_of: Kuva kohteesta
+        phone: soita puhelinnumeroon
+        browse_category: selaa tämän kategorian muita toimipisteitä
         route_here: Reitti tänne
         hours: Avoinna
         website: Kotisivu
@@ -238,12 +248,15 @@ sidebar:
         and: och
         browse: Alla tjänster
         browse_short: Alla
+        browse_button: öppna alla tjänster meny #TODO verify
         slogan: Din stad, dina tjänster
         search: Sök
+        close_search: stäng sökningen
         show: Visa
         show_tooltip: Visa på kartan
         hide_tooltip: Gömma på kartan
         hide: Göm
+        close_details: stäng verksamhetsställe detaljer fönstret #TODO verify
         back_to:
             search: Tillbaka till sökresultaten
             browse: Tillbaka till tjänsterna
@@ -253,6 +266,8 @@ sidebar:
             "104": Statens tjänst
             "105": Privat tjänst
             "102": Tjänst som stöds av kommunen
+        phone: ring telefonnumret
+        browse_category: Bläddra bland andra verksamhetsställen i den här kategorin
         hours: Öppet
         website: Webbplats
         events: Evenemang
@@ -891,6 +906,7 @@ assistive:
         to_frontpage: takaisin etusivulle
         navigation: Palvelut
         service_tree: Palveluluettelo
+        current_location_info: tietoa nykyisestä sijainnista
     en:
         zoom_in: zoom in
         zoom_out: zoom out
@@ -900,6 +916,7 @@ assistive:
         to_frontpage: back to the front page
         navigation: Services
         service_tree: List of services
+        current_location_info: information about current location
     sv:
         zoom_in: zooma in
         zoom_out: zooma ut
@@ -909,6 +926,7 @@ assistive:
         to_frontpage: otillbaka till första sidan
         navigation: Tjänster
         service_tree: Lista över tjänster
+        current_location_info: information om din nuvarande position
 tour:
     en:
         start: Start Feature Tour

--- a/locales/app.yaml
+++ b/locales/app.yaml
@@ -146,17 +146,17 @@ sidebar:
         and: and
         browse: All services
         browse_short: All
-        browse_button: open all services menu
+        browse_button: Open all services menu
         slogan: Your city, your services
         disclaimer: This is a beta version of the upcoming Helsinki area servicemap.
         search: Search
-        close_search: close search
+        close_search: Close search
         show: Show
         show_tooltip: Show on map
         hide_tooltip: Remove from map
         hide: Hide
         browse_tip: Click on title to show subtopics, or click 'show' to view services on the map.
-        close_details: close service point details window
+        close_details: Close service point details window
         back_to:
             search: Back to results
             browse: Back to services
@@ -167,8 +167,8 @@ sidebar:
             "104": State service
             "105": Private service
         picture_of: Picture of
-        phone: call telephone number
-        browse_category: browse other srvice points of this category
+        phone: Call telephone number
+        browse_category: Browse other service points of this category
         route_here: Route here
         hours: Opening hours
         website: Web site
@@ -197,17 +197,17 @@ sidebar:
         and: ja
         browse: Kaikki palvelut
         browse_short: Kaikki
-        browse_button: avaa kaikki palvelut valikko
+        browse_button: Avaa kaikki palvelut valikko
         slogan: Sinun kaupunkisi, sinun palvelusi
         disclaimer: Tämä on pääkaupunkiseudun uudistuvan palvelukartan beta-versio.
         search: Hae
-        close_search: sulje haku
+        close_search: Sulje haku
         show: Näytä
         show_tooltip: Näytä kartalla
         hide_tooltip: Poista kartalta
         hide: Piilota
         browse_tip: Klikkaa otsikosta näyttääksesi alipalvelut tai paina 'näytä', jos haluat nähdä palvelut kartalla.
-        close_details: sulje toimpisteen tideot ikkuna
+        close_details: Sulje toimpisteen tideot ikkuna
         back_to:
             search: Takaisin hakutuloksiin
             browse: Takaisin palveluihin
@@ -218,8 +218,8 @@ sidebar:
             "104": Valtion palvelu
             "105": Yksityinen palvelu
         picture_of: Kuva kohteesta
-        phone: soita puhelinnumeroon
-        browse_category: selaa tämän kategorian muita toimipisteitä
+        phone: Soita puhelinnumeroon
+        browse_category: Selaa tämän kategorian muita toimipisteitä
         route_here: Reitti tänne
         hours: Avoinna
         website: Kotisivu
@@ -248,15 +248,15 @@ sidebar:
         and: och
         browse: Alla tjänster
         browse_short: Alla
-        browse_button: öppna alla tjänster meny #TODO verify
+        browse_button: Öppna alla tjänster meny #TODO verify
         slogan: Din stad, dina tjänster
         search: Sök
-        close_search: stäng sökningen
+        close_search: Stäng sökningen
         show: Visa
         show_tooltip: Visa på kartan
         hide_tooltip: Gömma på kartan
         hide: Göm
-        close_details: stäng verksamhetsställe detaljer fönstret #TODO verify
+        close_details: Stäng verksamhetsställe detaljer fönstret #TODO verify
         back_to:
             search: Tillbaka till sökresultaten
             browse: Tillbaka till tjänsterna
@@ -266,7 +266,7 @@ sidebar:
             "104": Statens tjänst
             "105": Privat tjänst
             "102": Tjänst som stöds av kommunen
-        phone: ring telefonnumret
+        phone: Ring telefonnumret
         browse_category: Bläddra bland andra verksamhetsställen i den här kategorin
         hours: Öppet
         website: Webbplats
@@ -906,7 +906,7 @@ assistive:
         to_frontpage: takaisin etusivulle
         navigation: Palvelut
         service_tree: Palveluluettelo
-        current_location_info: tietoa nykyisestä sijainnista
+        current_location_info: Tietoa nykyisestä sijainnista
     en:
         zoom_in: zoom in
         zoom_out: zoom out
@@ -916,7 +916,7 @@ assistive:
         to_frontpage: back to the front page
         navigation: Services
         service_tree: List of services
-        current_location_info: information about current location
+        current_location_info: Information about current location
     sv:
         zoom_in: zooma in
         zoom_out: zooma ut
@@ -926,7 +926,7 @@ assistive:
         to_frontpage: otillbaka till första sidan
         navigation: Tjänster
         service_tree: Lista över tjänster
-        current_location_info: information om din nuvarande position
+        current_location_info: Information om din nuvarande position
 tour:
     en:
         start: Start Feature Tour

--- a/src/views/search-input.coffee
+++ b/src/views/search-input.coffee
@@ -1,6 +1,7 @@
 define (require) ->
     typeahead = require 'typeahead.bundle'
 
+    i18n      = require 'i18next'
     models    = require 'cs!app/models'
     jade      = require 'cs!app/jade'
     search    = require 'cs!app/search'
@@ -20,11 +21,13 @@ define (require) ->
                 $icon.addClass 'icon-icon-close'
                 $container.removeClass 'search-button'
                 $container.addClass 'close-button'
+                $icon.attr 'aria-label', i18n.t("sidebar.close_search")
             else
                 $icon.addClass 'icon-icon-forward-bold'
                 $icon.removeClass 'icon-icon-close'
                 $container.removeClass 'close-button'
                 $container.addClass 'search-button'
+                $icon.attr 'aria-label', i18n.t("sidebar.search")
         events:
             'typeahead:selected': 'autosuggestShowDetails'
             # Important! The following ensures the click

--- a/views/templates/details.jade
+++ b/views/templates/details.jade
@@ -35,12 +35,11 @@ mixin renderConnection(conn)
         span= name
 
 .content.limit-max-height(tabindex="-1")
-  h3.sr-only(title="#{t('accessibility.segment.service_point')} #{name}")
   .map-active-area
   .details-view-area
   if picture_url
     .image-wrapper
-      img.details-image(src="#{picture_url}", alt="#{t('sidebar.picture_of')} #{name}")
+      img.details-image(src="#{picture_url}", alt="#{t('sidebar.picture_of')} #{name}", aria-hidden="true")
       if picture_caption
         .details-image-caption
           = tAttr(picture_caption)
@@ -48,7 +47,8 @@ mixin renderConnection(conn)
   .section.main-info
     .header
       canvas#details-marker-canvas(width="30", height="30")
-      a.icon-icon-close(href="#")
+      h3.sr-only #{t('accessibility.segment.service_point')} #{name}
+      a.icon-icon-close(href="#", aria-label= t("sidebar.close_details"))
       h2(aria-hidden="true")
         span= name
 
@@ -67,23 +67,22 @@ mixin renderConnection(conn)
             | (#{t('sidebar.data_source', {data_source: data_source})})
 
       .address
-        address
-          if street_address
-            = street_address
-            if address_zip || municipality
-              |, &nbsp;
+        if street_address
+          = street_address
+          if address_zip || municipality
+            |, &nbsp;
+        if address_zip
+          = address_zip
+        if municipality
           if address_zip
-            = address_zip
-          if municipality
-            if address_zip
-              = ' '
-            = tAttr(municipality.name)
+            = ' '
+          = tAttr(municipality.name)
 
       if phone || tAttr(www)
         .contact-info
           if phone
             span(itemprop="telephone")
-              a.external-link(href="tel:#{phoneI18n(phone)}")= phone
+              a.external-link(href="tel:#{phoneI18n(phone)}" aria-label= "#{t('sidebar.phone')} #{phone}")= phone
           if phone && tAttr(www)
             | &nbsp; | &nbsp;
           if tAttr(www)
@@ -139,7 +138,7 @@ mixin renderConnection(conn)
       if services
         div.service
           for service in services
-            a.service-link(href="#" role="service-link" data-id=service.id) 
+            a.service-link(href="#" role="service-link" data-id=service.id aria-label="#{tAttr(service.name)}, #{t('sidebar.browse_category')}")
               span(class="service-node-background-color-#{service.color}" class="service-bullet")
               | &nbsp;
               = tAttr(service.name)
@@ -171,7 +170,7 @@ mixin renderConnection(conn)
       span.short-text
     #events-details.section-content.collapse
       .event-list
-      a.show-more-events(href="#")
+      a.show-more-events(href="#" aria-label= t('sidebar.show') +' '+ t('sidebar.show_more_events'))
         span= t('sidebar.show_more_events')
 
   if links && links.length

--- a/views/templates/location-refresh-button.jade
+++ b/views/templates/location-refresh-button.jade
@@ -1,3 +1,3 @@
 .location-refresh-header.sm-control-button-wrapper
   a.sm-control-button.location-button(href='#!', role="button")
-    span.icon-icon-you-are-here
+    span.icon-icon-you-are-here(aria-label=t("assistive.current_location_info"))

--- a/views/templates/navigation-header.jade
+++ b/views/templates/navigation-header.jade
@@ -2,4 +2,4 @@
   #search-region.header.search(role="textfield", data-type="search", tabindex="-1")
 .browse-container
   h2.sr-only=t('sidebar.browse')
-  #browse-region.header.browse(role="button", data-type="browse", tabindex="0")
+  #browse-region.header.browse(role="button", data-type="browse", tabindex="0", aria-label=t("sidebar.browse_button"))

--- a/views/templates/new-search-results.jade
+++ b/views/templates/new-search-results.jade
@@ -25,7 +25,7 @@ if !hidden
                   != t('search.sort.' + comparatorKey)
 
       div.header-column-collapse
-        a.collapse-button(href="#",role="button", tabindex="0")
+        a.collapse-button(href="#",role="button", tabindex="0", aria-hidden='true')
           span(class=collapsed ? 'icon-icon-expand' : 'icon-icon-collapse')
 
     div#list-controls.header-item(class = controls ? '' : 'hidden')

--- a/views/templates/personalisation.jade
+++ b/views/templates/personalisation.jade
@@ -16,9 +16,9 @@ mixin renderLanguage(code, name)
 
 
 .personalisation-header
+  h2.text= t('personalisation.personalise')
   a.personalisation-button(href="#", role="button")
     img.icon.icon-personalise(src=staticPath('icons/accessibility-person-circled.svg') alt=t('personalisation.personalise'))
-    h2.text= t('personalisation.personalise')
   a.close-button(href="#", role="button")= t('general.close')
   .selected-personalisations
 .personalisation-content


### PR DESCRIPTION
- Add descriptions to elements browsable with screen readers
- Change heading positions to improve screen reading order
- Remove unnecessary address tag around unit address
- Remove screen reader access to unnecessary collapse button