### PR TITLE
Fix/hide map options from screen readers

### DIFF
--- a/src/map-view.coffee
+++ b/src/map-view.coffee
@@ -497,6 +497,7 @@ define (require) ->
 
             @previousZoomlevel = @map.getZoom()
             @drawInitialState()
+            @$el.attr('tabindex', '-1') # Remove from tabindex hierarchy
 
         _removeBboxMarkers: (zoom, zoomLimit) ->
             unless @markers?

--- a/src/views/service-cart.coffee
+++ b/src/views/service-cart.coffee
@@ -7,6 +7,9 @@ define (require) ->
     class ServiceCartView extends base.SMItemView
         template: 'service-cart'
         tagName: 'ul'
+        attributes: {
+            'aria-hidden': 'true'
+        }
         className: 'expanded container main-list'
         events: ->
             'click .maximizer': 'maximize'


### PR DESCRIPTION
- Hide map options button from screen readers
- Hide map element from tabindex hierarchy