### PR TITLE
Remove automatic refresh when browsing radio buttons + add apply button

### DIFF
--- a/locales/app.yaml
+++ b/locales/app.yaml
@@ -93,6 +93,8 @@ service_cart:
             language_fi-se: Finnish and Sami speakers
             language_sv: Swedish speakers
             language_other: Other language speakers
+        apply_changes: Apply changes
+        
 
     fi:
         currently_on_map: Näkyvissä kartalla
@@ -122,6 +124,7 @@ service_cart:
             language_fi-se: Suomen- ja saamenkieliset
             language_sv: Ruotsinkieliset
             language_other: Muunkieliset
+        apply_changes: Ota muutokset käyttöön
     sv:
         currently_on_map: Synlig på kartan
         servicemap: Servicekarta
@@ -150,6 +153,7 @@ service_cart:
             language_fi: Finskspråkiga
             language_sv: Svenskspråkiga
             language_other: Andraspråkiga
+        apply_changes: Applicera förändringar # TODO verify
 sidebar:
     en:
         and: and

--- a/src/views/service-cart.coffee
+++ b/src/views/service-cart.coffee
@@ -18,12 +18,14 @@ define (require) ->
             'keydown .cart-close-button': @keyboardHandler @minimize, ['space', 'enter']
             'click .remove-service': 'removeServiceItem'
             'keydown .remove-service': @keyboardHandler @removeServiceItem, ['space', 'enter']
-            'click .map-layer input': 'selectLayerInput'
-            'click .map-layer label': 'selectLayerLabel'
+            'keydown .map-layer label': @keyboardHandler @selectLayerLabel, ['space', 'enter']
+            'click .apply': 'selectLayerInput'
             # 'click .data-layer a.toggle-layer': 'toggleDataLayer'
             #'click .data-layer label': 'selectDataLayerLabel'
-            'click .data-layer-heatmap input': (ev) -> @selectDataLayerInput('heatmap_layer', $(ev.currentTarget).prop('value'))
-            'click .data-layer-statistics input': @selectStatisticsLayerInput
+            'click .show-heat': 'selectDataLayerInput'
+            'keydown .data-layer-heatmap input': @keyboardHandler @selectDataLayerInput, ['space', 'enter']         
+            'click .show-statistics': @selectStatisticsLayerInput
+            'keydown .data-layer-statistics input': @keyboardHandler @selectStatisticsLayerInput, ['space', 'enter']
 
         initialize: ({@serviceNodes, @services, @selectedDataLayers}) ->
             for collection in [@serviceNodes, @services]
@@ -123,19 +125,21 @@ define (require) ->
             p13n.setMapBackgroundLayer value
 
         selectLayerInput: (event) ->
-            @_selectLayer $(event.currentTarget).attr('value')
+            @_selectLayer $('input:checked').attr('value')
 
         selectLayerLabel: (event) ->
             @_selectLayer $(event.currentTarget).data('layer')
 
-        selectDataLayerInput: (dataLayer, value) ->
+        selectDataLayerInput: (event) ->
+            dataLayer = 'heatmap_layer'
+            value = $('.heat:checked').prop('value')
             app.request 'removeDataLayer', dataLayer
-            unless value == 'null'
+            if value != 'null'
                 app.request 'addDataLayer', dataLayer, value
             @render()
 
         selectStatisticsLayerInput: (event) ->
-            value = $(event.currentTarget).prop('value')
+            value = $('.statistics:checked').prop('value')
             app.request 'removeDataLayer', 'statistics_layer'
             if value != 'null'
                 app.request 'showDivisions', null, value

--- a/views/templates/service-cart.jade
+++ b/views/templates/service-cart.jade
@@ -35,6 +35,7 @@ else
                 input(type='radio', name='map-layers', id!=layer_id, value!=layer.name, checked=checked, class=cls)
                 | &nbsp;
                 = t('service_cart.' + layer.name)
+            a.apply.blue-link(href='#')=t('service_cart.apply_changes')
   //- li.map-statistics
   //-   div.statistics.service-cart-collapser
   //-     span.layer-icon.icon-icon-areas-and-districts
@@ -81,9 +82,10 @@ else
               - checked = null
             - layer_id = 'layer-' + layer.name
             label.layer(data-layer=layer.name, for='heatmap-' +layer_id)
-              input(type='radio', name='heatmap-layers', id!='heatmap-' + layer_id, value='' + layer.name, checked=checked, class=cls)
+              input.heat(type='radio', name='heatmap-layers', id!='heatmap-' + layer_id, value='' + layer.name, checked=checked, class=cls)
               | &nbsp;
               = t('service_cart.data_layers.' + layer.name)
+          a.show-heat.blue-link(href='#')=t('sidebar.show_tooltip')
 
   li.data-layer.data-layer-statistics
     span.layer-icon.icon-icon-areas-and-districts
@@ -119,11 +121,12 @@ else
             - layerPath = layer.type ? layer.type + '.' + layer.name : 'null'
             - layer_id = 'layer-' + layerPath.replace('.', '-')
             label.layer(data-layer="#{layerPath}", for!='statistics-' + layer_id)
-              input(type='radio', name='statistics-layers', id!='statistics-' + layer_id, value=layerPath, checked=checked, class=cls)
+              input.statistics(type='radio', name='statistics-layers', id!='statistics-' + layer_id, value=layerPath, checked=checked, class=cls)
               | &nbsp;
               = t('service_cart.data_layers.' + layer.name)
               if layer.type === 'forecast'
                 span  (#{t('statistics.forecast')}&nbsp;2024/2025)
+        a.show-statistics.blue-link(href='#')=t('sidebar.show_tooltip')
 
   each item in items
     li.service-nodes


### PR DESCRIPTION
Add button to apply changes instead of automatically changing map when browsing radio buttons with arrow keys. Also add keydown events to quickly choose a radio button.