### PR TITLE
Add hidden language selector to screen reader users only

### DIFF
--- a/src/app.coffee
+++ b/src/app.coffee
@@ -379,6 +379,7 @@ define (require) ->
     app.addRegions
         navigation: '#navigation-region'
         personalisation: '#personalisation'
+        languageSelectorHidden: '#language-selector-hidden'
         languageSelector: '#language-selector'
         serviceCart: '#service-cart'
         landingLogo: '#landing-logo'
@@ -520,7 +521,13 @@ define (require) ->
 
         languageSelector = new LanguageSelectorView
             p13n: p13n
+            type: 'visible'
         @getRegion('languageSelector').show languageSelector
+
+        languageSelectorHidden = new LanguageSelectorView
+            p13n: p13n
+            type: 'hidden'
+        @getRegion('languageSelectorHidden').show languageSelectorHidden
 
         serviceCart = new ServiceCartView
             serviceNodes: appModels.selectedServiceNodes

--- a/src/p13n.coffee
+++ b/src/p13n.coffee
@@ -24,8 +24,8 @@ define (require) ->
     LOCALSTORAGE_KEY = 'servicemap_p13n'
     CURRENT_VERSION = 2
     LANGUAGE_NAMES =
-        fi: 'suomi'
-        sv: 'svenska'
+        fi: 'Suomi'
+        sv: 'Svenska'
         en: 'English'
     HEATMAP_LAYERS = dataviz.getHeatmapLayers()
 

--- a/src/views/language-selector.coffee
+++ b/src/views/language-selector.coffee
@@ -12,11 +12,13 @@ define (require) ->
         initialize: (opts) ->
             @p13n = opts.p13n
             @languages = @p13n.getSupportedLanguages()
+            @type = opts.type
             @refreshCollection()
             @listenTo p13n, 'url', =>
                 @render()
         serializeData: ->
             data = super()
+            data.type = @type
             for i, val of data.items
                 val.link = getLangURL val.code
             data

--- a/views/home.jade
+++ b/views/home.jade
@@ -11,11 +11,12 @@ block content
   img.cloud.cloud-bottom(src!=staticFile('images/cloud-bottom.png'), data-no-retina, alt="")
   #landing-logo.overlay
   #disclaimers.overlay
+  #language-selector-hidden.sr-only
   .top-left-controls
     #navigation-region.overlay
     #personalisation.overlay
   .top-right-controls
-    #language-selector.overlay
+    #language-selector.overlay(aria-hidden='true')
     #service-cart.overlay
   #images
   #app-container

--- a/views/templates/language-selector.jade
+++ b/views/templates/language-selector.jade
@@ -2,10 +2,11 @@
 h2.sr-only= t('personalisation.language')
 each item, index in items
   if index > 0
-    span.separator= ' | '
+    span.separator(aria-hidden='true')= ' | '
   if type == 'visible'
     a.external-link.language(href=item.link data-language!=item.code)
       = item.name
   else if type == 'hidden'
-    a.external-link.language(href=item.link data-language!=item.code tabindex='-1')
-      = item.name
+    div
+      a.external-link.language(href=item.link data-language!=item.code tabindex='-1')
+        = item.name

--- a/views/templates/language-selector.jade
+++ b/views/templates/language-selector.jade
@@ -3,5 +3,9 @@ h2.sr-only= t('personalisation.language')
 each item, index in items
   if index > 0
     span.separator= ' | '
-  a.external-link.language(href=item.link data-language!=item.code)
-    = item.name
+  if type == 'visible'
+    a.external-link.language(href=item.link data-language!=item.code)
+      = item.name
+  else if type == 'hidden'
+    a.external-link.language(href=item.link data-language!=item.code tabindex='-1')
+      = item.name


### PR DESCRIPTION
Created new language chooser to the front of the page that is only accessible with screen readers. Made the visible language chooser unreachable to screen readers. Also capitalised the language strings.