### PR TITLE
Fix NVDA issue with details window headings

### DIFF
--- a/views/templates/details.jade
+++ b/views/templates/details.jade
@@ -165,10 +165,10 @@ mixin renderConnection(conn)
 
   .section.events-section.hidden
     a.collapser.collapsed(role='button', aria-expanded="false", data-toggle="collapse", data-parent="#details-view-container", href="#events-details")
-      h3
+      h3(aria-label=t('sidebar.events'))
         span.icon-icon-events &nbsp;
         = t('sidebar.events')
-      span.short-text
+      span(aria-hidden='true').short-text
     #events-details.section-content.collapse
       .event-list
       a.show-more-events(href="#" aria-label= t('sidebar.show') +' '+ t('sidebar.show_more_events'))
@@ -177,10 +177,10 @@ mixin renderConnection(conn)
   if links && links.length
     .section
       a.collapser.collapsed(role='button', aria-expanded="false", data-toggle="collapse", data-parent="#details-view-container", href="#web-services-details")
-        h3
+        h3(aria-label=t('sidebar.web_services'))
           span.icon-icon-web-services &nbsp;
           = t('sidebar.web_services')
-        span.short-text= t('sidebar.service_count', {count: links.length})
+        span(aria-hidden='true').short-text= t('sidebar.service_count', {count: links.length})
       #web-services-details.section-content.collapse
         ul
           - each conn in links

--- a/views/templates/route.jade
+++ b/views/templates/route.jade
@@ -1,8 +1,8 @@
 a.collapser.collapsed.route(role='button', aria-expanded="false", data-toggle="collapse", data-parent="#details-view-container", href="#route-details")
-  h3
+  h3(aria-label=t('sidebar.route_here'))
     span#route-section-icon(class!=transit_icon) &nbsp;
     = t('sidebar.route_here')
-  span.short-text
+  span(aria-label='hidden').short-text
       span.length
       //= itinerary.duration
 #route-details.section-content.collapse

--- a/views/templates/unit-accessibility-details.jade
+++ b/views/templates/unit-accessibility-details.jade
@@ -9,10 +9,10 @@ mixin shortcomings(groups)
             li= detail
 
 a#accessibility-collapser.collapsed.collapser(role='button', aria-expanded="false", data-toggle="collapse", data-parent="#details-view-container", href="#accessibility-details", class="#{header_classes}")
-  h3
+  h3(aria-label=t('accessibility.accessibility'))
     span(class!=icon_class) &nbsp;
     = t('accessibility.accessibility')
-  span.short-text= short_text
+  span(aria-hidden='true').short-text= short_text
 
 #accessibility-details.section-content.collapse(class="#{collapse_classes}")
  if shortcomings_pending


### PR DESCRIPTION
Made screen reader focus skip short texts in details window headings (numbers of events, number of web services)