### PR TITLE
Fix focus on high contrast mode

### DIFF
--- a/styles/variables.less
+++ b/styles/variables.less
@@ -133,7 +133,7 @@
 @focus-width:                           2px;
 
 .block-element-focus{
-  outline: none;
+  outline: 2px solid transparent;
   box-shadow: 0 0 0 @focus-width rgba(25, 100, 230, 0.5);
   transition: @landing-transition;
 }


### PR DESCRIPTION
- Fix focus indicator not showing on windows high contrast mode