### PR TITLE
Use tiles.hel.ninja for maptiles instead of geoserver.hel.fi

### DIFF
--- a/src/map.coffee
+++ b/src/map.coffee
@@ -32,7 +32,7 @@ define (require) ->
                 else
                     "osm-sm/etrs_tm35fin"
         path = [
-            "https://geoserver.hel.fi/mapproxy/wmts",
+            "https://tiles.hel.ninja/wmts",
             stylePath,
             "{z}/{x}/{y}.png"
         ]


### PR DESCRIPTION
maptiles are canonically at tiles.hel.ninja, irregardless of the underlying server. geoserver.hel.fi is currently at a somewhat broken machine.